### PR TITLE
Relicense to dual Public Domain+ISC.

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,14 +1,36 @@
-            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
-                    Version 2, December 2004
+The authors, Darafei Praliaskouski (Komzpa) and Andrew Shadura,
+explicitly disclaim copyright in all jurisdictions which recognise such
+a disclaimer. In such jurisdictions, this software is released into the
+Public Domain.
 
- Copyright © 2009—2013 Darafei Praliaskoiski <me@komzpa.net>
-           © 2010—2013 Andrew Shadura <bugzilla@tut.by>
+In jurisdictions which do not recognise Public Domain property, this software is
 
- Everyone is permitted to copy and distribute verbatim or modified
- copies of this license document, and changing it is allowed as long
- as the name is changed.
+  Copyright © 2009—2013 Darafei Praliaskouski <me@komzpa.net>
+  Copyright © 2010—2013, 2016 Andrew Shadura <andrew@shadura.me>
 
-            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
-   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+and is released under the terms of the ISC License (see below).
 
-  0. You just DO WHAT THE FUCK YOU WANT TO.
+In jurisdictions which recognise Public Domain property, the user of this
+software may choose to accept it either as 1) Public Domain, 2) under
+the conditions of the ISC License (see below), or 3) under the terms of
+dual Public Domain/ISC License conditions described here, as they choose.
+
+The ISC License is compatible with both the copyleft and proprietary
+software, being as close to Public Domain as possible with the minor
+nuisance of being required to keep this copyright notice and license
+text in the source code. Note also that by accepting the Public Domain
+"license" you can re-license your copy using whatever license you like.
+
+The full text of the ISC License follows:
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND ISC DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL ISC BE LIABLE FOR ANY
+SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     url = 'https://github.com/komzpa/twms',
     description = 'tiny web map service',
     long_description = read('README.md'),
-    license = 'WTFPL',
+    license = 'Public Domain or ISC',
     packages = find_packages(),
     install_requires = ['Pillow', 'web.py'],
     extras_require = {

--- a/twms/bbox.py
+++ b/twms/bbox.py
@@ -3,9 +3,7 @@
 
 # This program is free software. It comes without any warranty, to
 # the extent permitted by applicable law. You can redistribute it
-# and/or modify it under the terms of the Do What The Fuck You Want
-# To Public License, Version 2, as published by Sam Hocevar. See
-# http://www.wtfpl.net/ for more details.
+# and/or modify it under the terms specified in COPYING.
 
 import sys
 import projections

--- a/twms/canvas.py
+++ b/twms/canvas.py
@@ -3,9 +3,7 @@
 
 # This program is free software. It comes without any warranty, to
 # the extent permitted by applicable law. You can redistribute it
-# and/or modify it under the terms of the Do What The Fuck You Want
-# To Public License, Version 2, as published by Sam Hocevar. See
-# http://www.wtfpl.net/ for more details.
+# and/or modify it under the terms specified in COPYING.
 
 ##
 ##  PP - PrePare

--- a/twms/capabilities.py
+++ b/twms/capabilities.py
@@ -3,9 +3,7 @@
 
 # This program is free software. It comes without any warranty, to
 # the extent permitted by applicable law. You can redistribute it
-# and/or modify it under the terms of the Do What The Fuck You Want
-# To Public License, Version 2, as published by Sam Hocevar. See
-# http://www.wtfpl.net/ for more details.
+# and/or modify it under the terms specified in COPYING.
 
 import config
 import projections

--- a/twms/correctify.py
+++ b/twms/correctify.py
@@ -3,9 +3,7 @@
 
 # This program is free software. It comes without any warranty, to
 # the extent permitted by applicable law. You can redistribute it
-# and/or modify it under the terms of the Do What The Fuck You Want
-# To Public License, Version 2, as published by Sam Hocevar. See
-# http://www.wtfpl.net/ for more details.
+# and/or modify it under the terms specified in COPYING.
 
 #import sys
 import projections

--- a/twms/daemon.py
+++ b/twms/daemon.py
@@ -4,9 +4,7 @@
 
 # This program is free software. It comes without any warranty, to
 # the extent permitted by applicable law. You can redistribute it
-# and/or modify it under the terms of the Do What The Fuck You Want
-# To Public License, Version 2, as published by Sam Hocevar. See
-# http://www.wtfpl.net/ for more details.
+# and/or modify it under the terms specified in COPYING.
 
 import web
 import sys

--- a/twms/drawing.py
+++ b/twms/drawing.py
@@ -3,9 +3,7 @@
 
 # This program is free software. It comes without any warranty, to
 # the extent permitted by applicable law. You can redistribute it
-# and/or modify it under the terms of the Do What The Fuck You Want
-# To Public License, Version 2, as published by Sam Hocevar. See
-# http://www.wtfpl.net/ for more details.
+# and/or modify it under the terms specified in COPYING.
 
 try:
     from PIL import Image, ImageDraw, ImageColor

--- a/twms/fetchers.py
+++ b/twms/fetchers.py
@@ -3,9 +3,7 @@
 
 # This program is free software. It comes without any warranty, to
 # the extent permitted by applicable law. You can redistribute it
-# and/or modify it under the terms of the Do What The Fuck You Want
-# To Public License, Version 2, as published by Sam Hocevar. See
-# http://www.wtfpl.net/ for more details.
+# and/or modify it under the terms specified in COPYING.
 
 import urllib2
 import filecmp

--- a/twms/filter.py
+++ b/twms/filter.py
@@ -3,9 +3,7 @@
 
 # This program is free software. It comes without any warranty, to
 # the extent permitted by applicable law. You can redistribute it
-# and/or modify it under the terms of the Do What The Fuck You Want
-# To Public License, Version 2, as published by Sam Hocevar. See
-# http://www.wtfpl.net/ for more details.
+# and/or modify it under the terms specified in COPYING.
 
 try:
     from PIL import Image, ImageFilter, ImageEnhance, ImageOps

--- a/twms/gpxparse.py
+++ b/twms/gpxparse.py
@@ -3,9 +3,7 @@
 
 # This program is free software. It comes without any warranty, to
 # the extent permitted by applicable law. You can redistribute it
-# and/or modify it under the terms of the Do What The Fuck You Want
-# To Public License, Version 2, as published by Sam Hocevar. See
-# http://www.wtfpl.net/ for more details.
+# and/or modify it under the terms specified in COPYING.
 
 import sys, string, bz2, gzip, os
 from xml.dom import minidom, Node

--- a/twms/overview.py
+++ b/twms/overview.py
@@ -3,9 +3,7 @@
 
 # This program is free software. It comes without any warranty, to
 # the extent permitted by applicable law. You can redistribute it
-# and/or modify it under the terms of the Do What The Fuck You Want
-# To Public License, Version 2, as published by Sam Hocevar. See
-# http://www.wtfpl.net/ for more details.
+# and/or modify it under the terms specified in COPYING.
 
 from config import *
 import projections

--- a/twms/projections.py
+++ b/twms/projections.py
@@ -2,9 +2,7 @@
 #    This file is part of twms.
 # This program is free software. It comes without any warranty, to
 # the extent permitted by applicable law. You can redistribute it
-# and/or modify it under the terms of the Do What The Fuck You Want
-# To Public License, Version 2, as published by Sam Hocevar. See
-# http://www.wtfpl.net/ for more details.
+# and/or modify it under the terms specified in COPYING.
 
 import math
 

--- a/twms/reproject.py
+++ b/twms/reproject.py
@@ -3,9 +3,7 @@
 
 # This program is free software. It comes without any warranty, to
 # the extent permitted by applicable law. You can redistribute it
-# and/or modify it under the terms of the Do What The Fuck You Want
-# To Public License, Version 2, as published by Sam Hocevar. See
-# http://www.wtfpl.net/ for more details.
+# and/or modify it under the terms specified in COPYING.
 
 try:
     from PIL import Image

--- a/twms/sketch.py
+++ b/twms/sketch.py
@@ -3,9 +3,7 @@
 
 # This program is free software. It comes without any warranty, to
 # the extent permitted by applicable law. You can redistribute it
-# and/or modify it under the terms of the Do What The Fuck You Want
-# To Public License, Version 2, as published by Sam Hocevar. See
-# http://www.wtfpl.net/ for more details.
+# and/or modify it under the terms specified in COPYING.
 
 from bbox import *
 

--- a/twms/twms.py
+++ b/twms/twms.py
@@ -4,9 +4,7 @@
 
 # This program is free software. It comes without any warranty, to
 # the extent permitted by applicable law. You can redistribute it
-# and/or modify it under the terms of the Do What The Fuck You Want
-# To Public License, Version 2, as published by Sam Hocevar. See
-# http://www.wtfpl.net/ for more details.
+# and/or modify it under the terms specified in COPYING.
 
 try:
     from PIL import Image, ImageOps, ImageColor


### PR DESCRIPTION
In #16, I proposed switching to MIT/Expat. As we’ve discussed in private, it’d be great to keep the publicdomainy property of WTFPL. Hence, I propose we actually do that and change to Public Domain with ISC as a backup. I chose ISC as it’s a bit simpler than Expat or BSD-2, and much shorter than the legal code of CC0, to which the resulting text seems to be equivalent.