### PR TITLE
Set encodnig when reading README.md

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ is_windows = __platform__ in ['Windows']
 __name__ = "twms"
 
 def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+    return open(os.path.join(os.path.dirname(__file__), fname), encoding='utf-8').read()
 
 def glob(fname):
     return abs_glob(os.path.join(os.path.dirname(__file__), fname))


### PR DESCRIPTION
Fixes `UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 86: ordinal not in range(128)`