### PR TITLE
Bootstrap semantic PR #21 rebuild

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,16 +48,7 @@ jobs:
         run: python -m compileall -q setup.py index.py tools twms
 
       - name: Import WSGI application
-        run: |
-          python - <<'PY'
-          import importlib.metadata
-          import twms
-          import twms.daemon
-
-          assert twms.__version__ == "0.07z"
-          assert importlib.metadata.version("twms") == "0.7+z"
-          print(type(twms.daemon.application).__name__)
-          PY
+        run: python -c "import importlib.metadata; import twms; import twms.daemon; assert twms.__version__ == '0.07z'; assert importlib.metadata.version('twms') == '0.7+z'; print(type(twms.daemon.application).__name__)"
 
       - name: Run legacy smoke tests
         run: python -m unittest discover -s tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ on:
       - published
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   package-smoke:
     name: Package smoke (${{ matrix.os }}, Python ${{ matrix.python-version }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,12 @@ on:
     branches:
       - master
       - "ai/**"
+    tags:
+      - "*"
   pull_request:
+  release:
+    types:
+      - published
   workflow_dispatch:
 
 jobs:
@@ -55,3 +60,49 @@ jobs:
 
       - name: Build source and wheel distributions
         run: python -m build
+
+  windows-exe:
+    name: Windows executable artifact
+    runs-on: windows-latest
+    needs: package-smoke
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install build tools
+        run: python -m pip install --upgrade pip pyinstaller
+
+      - name: Install package
+        run: python -m pip install -e .
+
+      - name: Write PyInstaller entry points
+        shell: pwsh
+        run: |
+          @'
+          from twms.server import main
+
+          if __name__ == "__main__":
+              main()
+          '@ | Set-Content -Encoding UTF8 twms-stdlib-entry.py
+
+          @'
+          from twms.daemon import main
+
+          if __name__ == "__main__":
+              main()
+          '@ | Set-Content -Encoding UTF8 twms-webpy-entry.py
+
+      - name: Build executables
+        run: |
+          python -m PyInstaller --onefile --name twms twms-stdlib-entry.py
+          python -m PyInstaller --onefile --name twms-webpy twms-webpy-entry.py
+
+      - name: Upload executable artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: twms-windows-exe-${{ github.sha }}
+          path: dist/*.exe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,5 +50,8 @@ jobs:
           print(type(twms.daemon.application).__name__)
           PY
 
+      - name: Run legacy smoke tests
+        run: python -m unittest discover -s tests
+
       - name: Build source and wheel distributions
         run: python -m build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+      - "ai/**"
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  package-smoke:
+    name: Package smoke (${{ matrix.os }}, Python ${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+        python-version:
+          - "3.11"
+          - "3.13"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install build tools
+        run: python -m pip install --upgrade pip build
+
+      - name: Install package
+        run: python -m pip install -e .
+
+      - name: Compile sources
+        run: python -m compileall -q setup.py index.py tools twms
+
+      - name: Import WSGI application
+        run: |
+          python - <<'PY'
+          import importlib.metadata
+          import twms
+          import twms.daemon
+
+          assert twms.__version__ == "0.07z"
+          assert importlib.metadata.version("twms") == "0.7+z"
+          print(type(twms.daemon.application).__name__)
+          PY
+
+      - name: Build source and wheel distributions
+        run: python -m build

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.py[cod]
+
+build/
+dist/
+*.egg-info/
+
+*.spec

--- a/COPYING
+++ b/COPYING
@@ -1,4 +1,5 @@
-The authors, Darafei Praliaskouski (Komzpa) and Andrew Shadura,
+The authors, Darafei Praliaskouski (Komzpa), Andrew Shadura, and
+Eugene Dvoretsky (Radioxoma),
 explicitly disclaim copyright in all jurisdictions which recognise such
 a disclaimer. In such jurisdictions, this software is released into the
 Public Domain.
@@ -7,6 +8,7 @@ In jurisdictions which do not recognise Public Domain property, this software is
 
   Copyright © 2009—2013 Darafei Praliaskouski <me@komzpa.net>
   Copyright © 2010—2013, 2016 Andrew Shadura <andrew@shadura.me>
+  Copyright © 2020—2021, 2023—2024 Eugene Dvoretsky <radioxoma@gmail.com>
 
 and is released under the terms of the ISC License (see below).
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ Layer dictionaries usually define:
 - `prefix`: cache subdirectory
 - `ext`: tile extension such as `jpg` or `png`
 - `proj`: tile pyramid projection, commonly `EPSG:3857` or `EPSG:3395`
-- `remote_url`: upstream tile URL template
+- `remote_url`: upstream tile URL template; legacy `%s/%s/%s` templates still
+  work, and named placeholders `{z}`, `{x}`, `{y}`, `{-y}`, and `{q}` are also
+  accepted for readable Slippy/TMS/Bing URLs
 - `fetch`: fetcher function, normally `fetchers.Tile`
 - `min_zoom` / `max_zoom`: optional zoom limits
 - `cache_ttl`: optional fresh-cache lifetime in seconds

--- a/README.md
+++ b/README.md
@@ -164,6 +164,9 @@ JOSM can also consume the generated imagery list:
 http://127.0.0.1:8080/josm/imagery.xml
 ```
 
+The generated list includes configured layer bounds, zoom limits, overlays,
+attribution URLs, and known no-tile MD5 checksums when those are present.
+
 For TWMS-specific parameters, use the WMS-style `GetTile` URL instead:
 
 ```text

--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ twms-webpy
 That path is kept for older deployments, including Windows/JOSM proxy
 bundles that depended on `web.py`.
 
+On GitHub, CI builds Windows executable artifacts for both entry points:
+
+- `twms.exe`
+- `twms-webpy.exe`
+
 ## Configuration
 
 twms loads Python configuration from:

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Layer dictionaries usually define:
 - `remote_url`: upstream tile URL template; legacy `%s/%s/%s` templates still
   work, and named placeholders `{z}`, `{x}`, `{y}`, `{-y}`, and `{q}` are also
   accepted for readable Slippy/TMS/Bing URLs
+- `headers`: optional upstream HTTP request headers, such as `Referer`,
+  `User-Agent`, or authentication cookies required by a particular source
 - `fetch`: fetcher function, normally `fetchers.Tile`
 - `min_zoom` / `max_zoom`: optional zoom limits
 - `cache_ttl`: optional fresh-cache lifetime in seconds

--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ Layer dictionaries usually define:
 - `fetch`: fetcher function, normally `fetchers.Tile`
 - `min_zoom` / `max_zoom`: optional zoom limits
 - `cache_ttl`: optional fresh-cache lifetime in seconds
+- `cache_layout`: optional cache path layout; the default is TWMS'
+  historical grouped layout, while `zxy` stores slippy/MOBAC-style
+  `<tiles_cache>/<prefix>/<z>/<x>/<y>.<ext>` tiles
 - `dead_tile`: optional dead-tile marker, either a legacy file path or a
   `{ "size": ..., "md5": {...} }` dictionary; dictionaries may also set
   `http_status` for an upstream status code that should be cached as `.tne`
@@ -149,7 +152,8 @@ tms:http://127.0.0.1:8080/?request=GetTile&layers=osm&z={zoom}&x={x}&y={y}&forma
 ```
 
 JOSM can also point directly at a compatible local slippy-map cache with
-`file://` if no proxy or reprojection is needed:
+`file://` if no proxy or reprojection is needed. Configure that layer with
+`cache_layout: "zxy"` so TWMS uses the same `<z>/<x>/<y>` path:
 
 ```text
 tms:file:///home/user/SAS.Planet/cache_ma/osm/{zoom}/{x}/{y}.png
@@ -163,7 +167,8 @@ tms:file:///C:/SAS.Planet/cache_ma/osm/{zoom}/{x}/{y}.png
 
 ## Shared tile caches
 
-twms keeps the historical filesystem cache layout under `tiles_cache`:
+By default, twms keeps the historical filesystem cache layout under
+`tiles_cache`:
 
 ```text
 <tiles_cache>/<prefix>/z<z>/<x // 1024>/x<x>/<y // 1024>/y<y>.<ext>
@@ -174,8 +179,13 @@ expires, twms tries to refresh the tile; if the remote fetch fails, the
 stale cached tile can still be used. Missing/dead tiles can be recorded
 as `.tne` files so repeated requests do not hammer upstream services.
 
-This makes twms useful with tools that share a slippy-map/MOBAC-style
-cache, including SAS.Planet and similar offline tile workflows.
+Layers that need to share a slippy-map/MOBAC-style cache, including
+SAS.Planet and similar offline tile workflows, can opt in with
+`cache_layout: "zxy"`:
+
+```text
+<tiles_cache>/<prefix>/<z>/<x>/<y>.<ext>
+```
 
 ## Optional dependencies
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ Layer dictionaries usually define:
   templates may use `{bbox}`, `{width}`, `{height}`, and `{proj}`
 - `headers`: optional upstream HTTP request headers, such as `Referer`,
   `User-Agent`, or authentication cookies required by a particular source
-- `fetch`: fetcher function, normally `fetchers.Tile`
+- `fetch`: fetcher function, normally `fetchers.Tile`; readable aliases
+  `"tms"` / `"tile"` and `"wms"` are also accepted
 - `timeout`: optional per-layer upstream HTTP timeout in seconds; set to
   `None` only if an old deployment deliberately wants the historical unbounded
   wait

--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ so GIS applications that support WMS protocol can access
 this tile set. Also, twms can act as a proxy and perform
 WMS requests to external services and serve the tile cache
 
+## Credits
+
+twms was originally written by Darafei Praliaskouski (Komzpa).
+Andrew Shadura maintains Debian packaging and wrote the Debian manpage.
+Eugene Dvoretsky (Radioxoma) contributed modernization work around
+packaging, serving, caching, and tile protocols.
+
 TODO
 ====
 

--- a/README.md
+++ b/README.md
@@ -1,32 +1,202 @@
-About
-=====
+# twms
 
-twms is a script that connects World of Tiles and World of WMS.
-The name ‘twms’ stands for twms web map server.
+twms is a tiny web map service that connects the world of tiles and
+the world of WMS.
 
-The primary purpose of twms is to export your map tiles to the
-WMS-enabled applications.
+The primary purpose of twms is to export raster tile sets to
+WMS-enabled GIS applications. It can also act as a small tile proxy:
+fetching remote tiles, keeping a filesystem cache, and serving that
+cache back through WMS, WMTS, TileJSON, or direct slippy-map tile URLs.
 
-twms can export a set of raster tiles as a WMS service
-so GIS applications that support WMS protocol can access
-this tile set. Also, twms can act as a proxy and perform
-WMS requests to external services and serve the tile cache
+twms intentionally stays small. The default server uses the Python
+standard library, while the older `web.py` WSGI/standalone path is
+still available for deployments that already use it.
+
+## Install and run
+
+Install from a checkout:
+
+```sh
+python -m pip install -e .
+```
+
+Run the default stdlib server:
+
+```sh
+twms 8080
+```
+
+or:
+
+```sh
+python -m twms 8080
+```
+
+The previous `web.py` server and WSGI adapter are still installed as:
+
+```sh
+twms-webpy
+```
+
+That path is kept for older deployments, including Windows/JOSM proxy
+bundles that depended on `web.py`.
+
+## Configuration
+
+twms loads Python configuration from:
+
+1. `/etc/twms/twms.conf`
+2. the packaged `twms/twms.conf`
+3. `twms.conf` in the current script directory
+
+Important settings:
+
+- `tiles_cache`: root directory for the filesystem tile cache
+- `gpx_cache`: cache for downloaded OSM GPX traces
+- `service_url`: externally visible base URL used in generated capabilities
+- `default_layers`: layer list used when a request does not name layers
+- `default_format`: output image MIME type, usually `image/jpeg`
+- `layers`: configured imagery layers and their fetchers
+
+Layer dictionaries usually define:
+
+- `name`: human readable title
+- `prefix`: cache subdirectory
+- `ext`: tile extension such as `jpg` or `png`
+- `proj`: tile pyramid projection, commonly `EPSG:3857` or `EPSG:3395`
+- `remote_url`: upstream tile URL template
+- `fetch`: fetcher function, normally `fetchers.Tile`
+- `min_zoom` / `max_zoom`: optional zoom limits
+- `cache_ttl`: optional fresh-cache lifetime in seconds
+- `dead_tile`: optional dead-tile marker, either a legacy file path or a
+  `{ "size": ..., "md5": {...} }` dictionary
+
+## Client URLs
+
+Assuming the server runs at `http://127.0.0.1:8080/`:
+
+- overview page:
+  `http://127.0.0.1:8080/`
+- WMS 1.1.1/1.3.0 endpoint:
+  `http://127.0.0.1:8080/`
+- WMS capabilities:
+  `http://127.0.0.1:8080/?service=WMS&request=GetCapabilities&version=1.3.0`
+- WMTS capabilities:
+  `http://127.0.0.1:8080/wmts/1.0.0/WMTSCapabilities.xml`
+- TileJSON for a layer:
+  `http://127.0.0.1:8080/tilejson/osm.json`
+- direct tile URL:
+  `http://127.0.0.1:8080/osm/{z}/{x}/{y}.png`
+- WMTS REST tile URL:
+  `http://127.0.0.1:8080/wmts/osm/{z}/{x}/{y}.png`
+
+The legacy `GetTile` request is still supported because it is useful
+when clients need filters or other TWMS-specific request parameters in
+the tile URL:
+
+```text
+http://127.0.0.1:8080/?request=GetTile&layers=osm&z={z}&x={x}&y={y}&format=png
+```
+
+## QGIS
+
+For WMS, create a WMS/WMTS connection pointing at:
+
+```text
+http://127.0.0.1:8080/
+```
+
+QGIS may request WMS 1.3.0 capabilities with uppercase parameter names
+such as `SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.3.0`; twms
+accepts those. WMS 1.3.0 also accepts the `crs` parameter and advertises
+`CRS:84` for lon/lat bounds, while the old WMS 1.1.1 capabilities keep
+their existing `SRS` listings.
+
+For WMTS, use:
+
+```text
+http://127.0.0.1:8080/wmts/1.0.0/WMTSCapabilities.xml
+```
+
+## JOSM
+
+For a normal local proxy, add a TMS imagery entry such as:
+
+```text
+tms:http://127.0.0.1:8080/osm/{zoom}/{x}/{y}.png
+```
+
+For TWMS-specific parameters, use the WMS-style `GetTile` URL instead:
+
+```text
+tms:http://127.0.0.1:8080/?request=GetTile&layers=osm&z={zoom}&x={x}&y={y}&format=png
+```
+
+JOSM can also point directly at a compatible local slippy-map cache with
+`file://` if no proxy or reprojection is needed:
+
+```text
+tms:file:///home/user/SAS.Planet/cache_ma/osm/{zoom}/{x}/{y}.png
+```
+
+On Windows the same idea uses a Windows path:
+
+```text
+tms:file:///C:/SAS.Planet/cache_ma/osm/{zoom}/{x}/{y}.png
+```
+
+## Shared tile caches
+
+twms keeps the historical filesystem cache layout under `tiles_cache`:
+
+```text
+<tiles_cache>/<prefix>/z<z>/<x // 1024>/x<x>/<y // 1024>/y<y>.<ext>
+```
+
+Fresh cached tiles are served without network access. When `cache_ttl`
+expires, twms tries to refresh the tile; if the remote fetch fails, the
+stale cached tile can still be used. Missing/dead tiles can be recorded
+as `.tne` files so repeated requests do not hammer upstream services.
+
+This makes twms useful with tools that share a slippy-map/MOBAC-style
+cache, including SAS.Planet and similar offline tile workflows.
+
+## Optional dependencies
+
+The base install keeps dependencies small:
+
+- `Pillow`
+- `web.py` for the legacy WSGI/standalone server path
+
+Optional extras:
+
+```sh
+python -m pip install -e '.[proj]'
+python -m pip install -e '.[cairo]'
+```
+
+`twms[proj]` enables pyproj-backed transformations for configured
+non-core projections. Without it, twms still has built-in pure-Python
+support for the common EPSG:4326/EPSG:3857/EPSG:3395 path.
+
+`twms[cairo]` enables Cairo-backed vector rendering where the old
+rendering path uses it.
 
 ## Credits
 
 twms was originally written by Darafei Praliaskouski (Komzpa).
 Andrew Shadura maintains Debian packaging and wrote the Debian manpage.
 Eugene Dvoretsky (Radioxoma) contributed modernization work around
-packaging, serving, caching, and tile protocols.
+packaging, serving, caching, projections, documentation, and tile
+protocols.
 
-TODO
-====
+## TODO
 
- - Make fetchers work with proxy
- - Full reprojection support
- - Imagery realignment
+- Make fetchers work with proxy.
+- Full reprojection support.
+- Imagery realignment.
 
-Conventions
-===========
+## Conventions
 
- - Inside tWMS, only EPSG:4326 latlon should be used for transmitting coordinates.
+- Inside twms, EPSG:4326 lon/lat should be used for transmitting
+  coordinates.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ Layer dictionaries usually define:
   `{ "size": ..., "md5": {...} }` dictionary; dictionaries may also set
   `http_status` for an upstream status code that should be cached as `.tne`
 
+TWMS intentionally does not read browser cookie stores automatically. If a
+private deployment needs a short-lived cookie, copy it into the layer `headers`
+or load it from your own local config code so the server does not gain a
+browser-profile dependency.
+
 ## Client URLs
 
 Assuming the server runs at `http://127.0.0.1:8080/`:

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ Important settings:
 - `tiles_cache`: root directory for the filesystem tile cache
 - `gpx_cache`: cache for downloaded OSM GPX traces
 - `service_url`: externally visible base URL used in generated capabilities
+- `upstream_timeout`: default upstream HTTP timeout in seconds; the example
+  config uses 30 seconds so threaded servers do not wait forever on a stalled
+  tile source
 - `default_layers`: layer list used when a request does not name layers
 - `default_format`: output image MIME type, usually `image/jpeg`
 - `layers`: configured imagery layers and their fetchers
@@ -76,6 +79,9 @@ Layer dictionaries usually define:
 - `headers`: optional upstream HTTP request headers, such as `Referer`,
   `User-Agent`, or authentication cookies required by a particular source
 - `fetch`: fetcher function, normally `fetchers.Tile`
+- `timeout`: optional per-layer upstream HTTP timeout in seconds; set to
+  `None` only if an old deployment deliberately wants the historical unbounded
+  wait
 - `min_zoom` / `max_zoom`: optional zoom limits
 - `cache_ttl`: optional fresh-cache lifetime in seconds
 - `cache_layout`: optional cache path layout; the default is TWMS'

--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ For a normal local proxy, add a TMS imagery entry such as:
 tms:http://127.0.0.1:8080/osm/{zoom}/{x}/{y}.png
 ```
 
+JOSM can also consume the generated imagery list:
+
+```text
+http://127.0.0.1:8080/josm/imagery.xml
+```
+
 For TWMS-specific parameters, use the WMS-style `GetTile` URL instead:
 
 ```text

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ Layer dictionaries usually define:
 - `min_zoom` / `max_zoom`: optional zoom limits
 - `cache_ttl`: optional fresh-cache lifetime in seconds
 - `dead_tile`: optional dead-tile marker, either a legacy file path or a
-  `{ "size": ..., "md5": {...} }` dictionary
+  `{ "size": ..., "md5": {...} }` dictionary; dictionaries may also set
+  `http_status` for an upstream status code that should be cached as `.tne`
 
 ## Client URLs
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ Important settings:
 - `upstream_timeout`: default upstream HTTP timeout in seconds; the example
   config uses 30 seconds so threaded servers do not wait forever on a stalled
   tile source
+- `upstream_retries` / `upstream_retry_delay`: optional retry budget for
+  transient upstream network errors. The default is one attempt, preserving the
+  historical no-retry behavior; layers can opt in with their own values.
 - `default_layers`: layer list used when a request does not name layers
 - `default_format`: output image MIME type, usually `image/jpeg`
 - `layers`: configured imagery layers and their fetchers
@@ -82,6 +85,10 @@ Layer dictionaries usually define:
 - `timeout`: optional per-layer upstream HTTP timeout in seconds; set to
   `None` only if an old deployment deliberately wants the historical unbounded
   wait
+- `upstream_retries` / `upstream_retry_delay`: optional per-layer retry
+  override for temporary network failures. HTTP errors such as 404 are still
+  handled by the cache/TNE rules instead of being retried as generic transport
+  failures.
 - `min_zoom` / `max_zoom`: optional zoom limits
 - `cache_ttl`: optional fresh-cache lifetime in seconds
 - `cache_layout`: optional cache path layout; the default is TWMS'

--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ On GitHub, CI builds Windows executable artifacts for both entry points:
 - `twms.exe`
 - `twms-webpy.exe`
 
+Optional launcher templates are shipped under `share/twms/contrib`:
+
+- `twms.bat` starts `python -m twms` minimized for small Windows/JOSM proxy
+  deployments.
+- `twms.desktop` is a simple terminal desktop-entry template for Linux
+  desktops or downstream packages.
+
 ## Configuration
 
 twms loads Python configuration from:

--- a/README.md
+++ b/README.md
@@ -69,9 +69,10 @@ Layer dictionaries usually define:
 - `prefix`: cache subdirectory
 - `ext`: tile extension such as `jpg` or `png`
 - `proj`: tile pyramid projection, commonly `EPSG:3857` or `EPSG:3395`
-- `remote_url`: upstream tile URL template; legacy `%s/%s/%s` templates still
-  work, and named placeholders `{z}`, `{x}`, `{y}`, `{-y}`, and `{q}` are also
-  accepted for readable Slippy/TMS/Bing URLs
+- `remote_url`: upstream tile/WMS URL template; legacy tile `%s/%s/%s`
+  templates still work, named tile placeholders `{z}`, `{x}`, `{y}`, `{-y}`,
+  and `{q}` are accepted for readable Slippy/TMS/Bing URLs, and WMS upstream
+  templates may use `{bbox}`, `{width}`, `{height}`, and `{proj}`
 - `headers`: optional upstream HTTP request headers, such as `Referer`,
   `User-Agent`, or authentication cookies required by a particular source
 - `fetch`: fetcher function, normally `fetchers.Tile`

--- a/contrib/twms.bat
+++ b/contrib/twms.bat
@@ -1,0 +1,3 @@
+@echo off
+rem Start TWMS minimized for small Windows/JOSM proxy deployments.
+start "twms" /MIN python -m twms %*

--- a/contrib/twms.desktop
+++ b/contrib/twms.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=TWMS
+GenericName=Tiny WMS/TMS server
+Comment=Start the tiny WMS/TMS tile proxy
+Categories=Geoscience;Geography;Network;
+Exec=twms
+Terminal=true
+StartupNotify=false
+Icon=utilities-terminal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = twms
-version = 0.07z
+version = attr: twms.version.__packaging_version__
 author = Darafei Praliaskouski
 author_email = me@komzpa.net
 url = https://github.com/komzpa/twms
@@ -15,12 +15,14 @@ classifiers =
     License :: Public Domain
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Internet :: WWW/HTTP
     Topic :: Scientific/Engineering :: GIS
 
 [options]
-python_requires = >= 3.6
+python_requires = >= 3.11
 packages = find:
 install_requires =
     Pillow

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,8 @@ cairo = pycairo
 
 [options.entry_points]
 console_scripts =
-    twms = twms.daemon:main
+    twms = twms.server:main
+    twms-webpy = twms.daemon:main
 
 [flake8]
 doctests = yes

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
         (os.path.join('share', 'doc', __name__), ['COPYING']),
         (os.path.join('share', 'doc', __name__), glob('*.md')),
         (os.path.join('share', __name__), glob('*.jpg')),
-        (os.path.join('share', __name__, 'tools'), glob(os.path.join('tools', '*.py')))
+        (os.path.join('share', __name__, 'tools'), glob(os.path.join('tools', '*.py'))),
+        (os.path.join('share', __name__, 'contrib'), glob(os.path.join('contrib', '*'))),
     ] + man_files('*.1') + config_files(),
 )

--- a/tests/test_legacy_smoke.py
+++ b/tests/test_legacy_smoke.py
@@ -1,5 +1,6 @@
 import importlib
 import importlib.metadata
+import json
 from io import BytesIO
 import threading
 import unittest
@@ -76,6 +77,26 @@ class LegacySmokeTest(unittest.TestCase):
             self.assertEqual(image.size, (256, 256))
             self.assertEqual(image.mode, "RGBA")
 
+    def test_tilejson_smoke(self):
+        status, content_type, body = twms.twms.twms_main(
+            {
+                "request": "GetTileJSON",
+                "layers": "osm",
+                "ref": "http://example.test/",
+            }
+        )
+
+        doc = json.loads(body)
+        self.assertEqual(status, 200)
+        self.assertEqual(content_type, "application/json")
+        self.assertEqual(doc["tilejson"], "3.0.0")
+        self.assertEqual(doc["name"], "OpenStreetMap mapnik")
+        self.assertEqual(doc["scheme"], "xyz")
+        self.assertEqual(doc["tiles"], ["http://example.test/osm/{z}/{x}/{y}.png"])
+        self.assertEqual(doc["bounds"], [-180.0, -85.0511287798, 180.0, 85.0511287798])
+        self.assertEqual(doc["minzoom"], 0)
+        self.assertEqual(doc["maxzoom"], 18)
+
     def test_wsgi_application_imports(self):
         self.assertTrue(callable(twms.daemon.application))
 
@@ -101,6 +122,12 @@ class LegacySmokeTest(unittest.TestCase):
                 with Image.open(BytesIO(body)) as image:
                     self.assertEqual(image.size, (256, 256))
                     self.assertEqual(image.mode, "RGBA")
+
+            with urllib.request.urlopen(base + "/tilejson/osm.json") as response:
+                doc = json.loads(response.read().decode("utf-8"))
+                self.assertEqual(response.status, 200)
+                self.assertIn("application/json", response.headers["Content-Type"])
+                self.assertEqual(doc["tiles"], [base + "/osm/{z}/{x}/{y}.png"])
         finally:
             httpd.shutdown()
             httpd.server_close()

--- a/tests/test_legacy_smoke.py
+++ b/tests/test_legacy_smoke.py
@@ -351,6 +351,34 @@ class LegacySmokeTest(unittest.TestCase):
         self.assertEqual(doc["minzoom"], 0)
         self.assertEqual(doc["maxzoom"], 18)
 
+    def test_tilejson_accepts_layer_bounds_alias(self):
+        old_layers = twms.twms.config.layers
+        twms.twms.config.layers = {
+            "bounded": {
+                "name": "Bounded",
+                "prefix": "bounded",
+                "ext": "png",
+                "proj": "EPSG:3857",
+                "bounds": (1.0, 2.0, 3.0, 4.0),
+            }
+        }
+        try:
+            status, content_type, body = twms.twms.twms_main(
+                {
+                    "request": "GetTileJSON",
+                    "layers": "bounded",
+                    "ref": "http://example.test/",
+                }
+            )
+
+            doc = json.loads(body)
+            self.assertEqual(status, 200)
+            self.assertEqual(content_type, "application/json")
+            self.assertEqual(doc["bounds"], [1.0, 2.0, 3.0, 4.0])
+            self.assertEqual(doc["center"], [2.0, 3.0, 0])
+        finally:
+            twms.twms.config.layers = old_layers
+
     def test_josm_imagery_xml_smoke(self):
         status, content_type, body = twms.twms.twms_main(
             {
@@ -409,6 +437,43 @@ class LegacySmokeTest(unittest.TestCase):
             resource.attrib["template"],
             "http://example.test/wmts/osm/{TileMatrix}/{TileCol}/{TileRow}.png",
         )
+
+    def test_wmts_capabilities_accepts_layer_bounds_alias(self):
+        old_layers = twms.twms.config.layers
+        twms.twms.config.layers = {
+            "bounded": {
+                "name": "Bounded",
+                "prefix": "bounded",
+                "ext": "png",
+                "proj": "EPSG:3857",
+                "bounds": (1.0, 2.0, 3.0, 4.0),
+            }
+        }
+        try:
+            status, content_type, body = twms.twms.twms_main(
+                {
+                    "service": "WMTS",
+                    "request": "GetCapabilities",
+                    "ref": "http://example.test/",
+                }
+            )
+
+            root = ET.fromstring(body)
+            namespaces = {
+                "wmts": "http://www.opengis.net/wmts/1.0",
+                "ows": "http://www.opengis.net/ows/1.1",
+            }
+            bounds = root.find(
+                "./wmts:Contents/wmts:Layer[ows:Identifier='bounded']/ows:WGS84BoundingBox",
+                namespaces,
+            )
+
+            self.assertEqual(status, 200)
+            self.assertEqual(content_type, "text/xml")
+            self.assertEqual(bounds.find("ows:LowerCorner", namespaces).text, "1.0 2.0")
+            self.assertEqual(bounds.find("ows:UpperCorner", namespaces).text, "3.0 4.0")
+        finally:
+            twms.twms.config.layers = old_layers
 
     def test_wmts_kvp_gettile_smoke(self):
         status, content_type, body = twms.twms.twms_main(
@@ -1087,6 +1152,29 @@ class LegacySmokeTest(unittest.TestCase):
 
         self.assertIsNone(image)
         urlopen.assert_not_called()
+
+    def test_legacy_tile_image_accepts_layer_bounds_alias(self):
+        layer = {
+            "prefix": "bounded",
+            "ext": "png",
+            "proj": "EPSG:3857",
+            "bounds": (170.0, -80.0, 171.0, -79.0),
+            "scalable": False,
+            "fetch": twms.fetchers.Tile,
+            "remote_url": "http://example.test/%s/%s/%s.png",
+        }
+
+        with mock.patch("twms.fetchers.fetch") as fetch:
+            image = twms.twms.tile_image(
+                layer,
+                2,
+                0,
+                0,
+                datetime.datetime.now(),
+            )
+
+        self.assertIsNone(image)
+        fetch.assert_not_called()
 
     def test_wms_fetcher_respects_min_zoom(self):
         layer = {

--- a/tests/test_legacy_smoke.py
+++ b/tests/test_legacy_smoke.py
@@ -6,6 +6,7 @@ import threading
 import unittest
 import urllib.request
 from http.server import ThreadingHTTPServer
+import xml.etree.ElementTree as ET
 
 from PIL import Image
 
@@ -32,6 +33,7 @@ class LegacySmokeTest(unittest.TestCase):
             "twms.projections",
             "twms.reproject",
             "twms.sketch",
+            "twms.wmts",
         ]
         for module in modules:
             with self.subTest(module=module):
@@ -97,6 +99,60 @@ class LegacySmokeTest(unittest.TestCase):
         self.assertEqual(doc["minzoom"], 0)
         self.assertEqual(doc["maxzoom"], 18)
 
+    def test_wmts_capabilities_smoke(self):
+        status, content_type, body = twms.twms.twms_main(
+            {
+                "service": "WMTS",
+                "request": "GetCapabilities",
+                "ref": "http://example.test/",
+            }
+        )
+
+        root = ET.fromstring(body)
+        namespaces = {
+            "wmts": "http://www.opengis.net/wmts/1.0",
+            "ows": "http://www.opengis.net/ows/1.1",
+        }
+        layer_ids = [
+            element.text
+            for element in root.findall(
+                "./wmts:Contents/wmts:Layer/ows:Identifier",
+                namespaces,
+            )
+        ]
+        resource = root.find(
+            "./wmts:Contents/wmts:Layer[ows:Identifier='osm']/wmts:ResourceURL",
+            namespaces,
+        )
+
+        self.assertEqual(status, 200)
+        self.assertEqual(content_type, "text/xml")
+        self.assertEqual(root.tag, "{http://www.opengis.net/wmts/1.0}Capabilities")
+        self.assertIn("osm", layer_ids)
+        self.assertEqual(
+            resource.attrib["template"],
+            "http://example.test/wmts/osm/{TileMatrix}/{TileCol}/{TileRow}.png",
+        )
+
+    def test_wmts_kvp_gettile_smoke(self):
+        status, content_type, body = twms.twms.twms_main(
+            {
+                "service": "WMTS",
+                "request": "GetTile",
+                "layer": "transparent",
+                "format": "image/png",
+                "tilematrix": "0",
+                "tilecol": "0",
+                "tilerow": "0",
+            }
+        )
+
+        self.assertEqual(status, 200)
+        self.assertEqual(content_type, "image/png")
+        with Image.open(BytesIO(body)) as image:
+            self.assertEqual(image.size, (256, 256))
+            self.assertEqual(image.mode, "RGBA")
+
     def test_wsgi_application_imports(self):
         self.assertTrue(callable(twms.daemon.application))
 
@@ -128,6 +184,25 @@ class LegacySmokeTest(unittest.TestCase):
                 self.assertEqual(response.status, 200)
                 self.assertIn("application/json", response.headers["Content-Type"])
                 self.assertEqual(doc["tiles"], [base + "/osm/{z}/{x}/{y}.png"])
+
+            with urllib.request.urlopen(
+                base + "/wmts/1.0.0/WMTSCapabilities.xml"
+            ) as response:
+                root = ET.fromstring(response.read().decode("utf-8"))
+                self.assertEqual(response.status, 200)
+                self.assertIn("text/xml", response.headers["Content-Type"])
+                self.assertEqual(
+                    root.tag,
+                    "{http://www.opengis.net/wmts/1.0}Capabilities",
+                )
+
+            with urllib.request.urlopen(base + "/wmts/transparent/0/0/0.png") as response:
+                body = response.read()
+                self.assertEqual(response.status, 200)
+                self.assertIn("image/png", response.headers["Content-Type"])
+                with Image.open(BytesIO(body)) as image:
+                    self.assertEqual(image.size, (256, 256))
+                    self.assertEqual(image.mode, "RGBA")
         finally:
             httpd.shutdown()
             httpd.server_close()

--- a/tests/test_legacy_smoke.py
+++ b/tests/test_legacy_smoke.py
@@ -488,6 +488,76 @@ class LegacySmokeTest(unittest.TestCase):
             finally:
                 twms.fetchers.config.tiles_cache = old_cache
 
+    def test_legacy_tile_image_reuses_historical_cache_path(self):
+        with tempfile.TemporaryDirectory() as cache_root:
+            old_cache = twms.twms.config.tiles_cache
+            twms.twms.config.tiles_cache = cache_root + os.sep
+            layer = {
+                "prefix": "legacy-hit",
+                "proj": "EPSG:3857",
+                "ext": "png",
+                "cached": True,
+                "scalable": False,
+                "empty_color": "#000000",
+                "fetch": mock.Mock(return_value=None),
+            }
+            try:
+                path = self.cache_path(cache_root, layer, 3, 3, 3)
+                os.makedirs(os.path.dirname(path))
+                with open(path, "wb") as cached_tile:
+                    cached_tile.write(self.image_bytes((10, 20, 30, 255)))
+
+                image = twms.twms.tile_image(
+                    layer,
+                    3,
+                    3,
+                    3,
+                    datetime.datetime.now(),
+                    real=True,
+                )
+
+                layer["fetch"].assert_not_called()
+                self.assertEqual(image.getpixel((0, 0)), (10, 20, 30, 255))
+            finally:
+                twms.twms.config.tiles_cache = old_cache
+
+    def test_legacy_gettile_fast_cache_reads_binary_tile(self):
+        with tempfile.TemporaryDirectory() as cache_root:
+            old_cache = twms.twms.config.tiles_cache
+            old_layers = twms.twms.config.layers
+            twms.twms.config.tiles_cache = cache_root + os.sep
+            layer = {
+                "prefix": "legacy-fast-hit",
+                "proj": "EPSG:3857",
+                "ext": "png",
+            }
+            twms.twms.config.layers = {"legacy-fast-hit": layer}
+            try:
+                path = self.cache_path(cache_root, layer, 3, 3, 4)
+                os.makedirs(os.path.dirname(path))
+                with open(path, "wb") as cached_tile:
+                    cached_tile.write(self.image_bytes((10, 20, 30, 255)))
+
+                status, content_type, body = twms.twms.twms_main(
+                    {
+                        "request": "GetTile",
+                        "layers": "legacy-fast-hit",
+                        "format": "image/png",
+                        "z": "2",
+                        "x": "3",
+                        "y": "4",
+                    }
+                )
+
+                self.assertEqual(status, 200)
+                self.assertEqual(content_type, "image/png")
+                self.assertIsInstance(body, bytes)
+                with Image.open(BytesIO(body)) as image:
+                    self.assertEqual(image.getpixel((0, 0)), (10, 20, 30, 255))
+            finally:
+                twms.twms.config.tiles_cache = old_cache
+                twms.twms.config.layers = old_layers
+
     def test_tile_cache_can_use_zxy_layout(self):
         with tempfile.TemporaryDirectory() as cache_root:
             old_cache = twms.fetchers.config.tiles_cache

--- a/tests/test_legacy_smoke.py
+++ b/tests/test_legacy_smoke.py
@@ -558,6 +558,80 @@ class LegacySmokeTest(unittest.TestCase):
                 twms.twms.config.tiles_cache = old_cache
                 twms.twms.config.layers = old_layers
 
+    def test_legacy_response_cache_reads_binary_tile(self):
+        with tempfile.TemporaryDirectory() as cache_root:
+            old_cache = getattr(twms.twms.config, "cache_tile_responses", None)
+            had_cache = hasattr(twms.twms.config, "cache_tile_responses")
+            twms.twms.config.cache_tile_responses = {
+                ("EPSG:3857", ("transparent",), (), 256, 256, (), "PNG"): (
+                    cache_root,
+                    "png",
+                ),
+            }
+            try:
+                path = os.path.join(cache_root, "2", "3", "4.png")
+                os.makedirs(os.path.dirname(path))
+                with open(path, "wb") as cached_tile:
+                    cached_tile.write(self.image_bytes((10, 20, 30, 255)))
+
+                status, content_type, body = twms.twms.twms_main(
+                    {
+                        "request": "GetTile",
+                        "layers": "transparent",
+                        "format": "image/png",
+                        "z": "2",
+                        "x": "3",
+                        "y": "4",
+                    }
+                )
+
+                self.assertEqual(status, 200)
+                self.assertEqual(content_type, "image/png")
+                self.assertIsInstance(body, bytes)
+                with Image.open(BytesIO(body)) as image:
+                    self.assertEqual(image.getpixel((0, 0)), (10, 20, 30, 255))
+            finally:
+                if had_cache:
+                    twms.twms.config.cache_tile_responses = old_cache
+                else:
+                    del twms.twms.config.cache_tile_responses
+
+    def test_legacy_response_cache_writes_binary_tile(self):
+        with tempfile.TemporaryDirectory() as cache_root:
+            old_cache = getattr(twms.twms.config, "cache_tile_responses", None)
+            had_cache = hasattr(twms.twms.config, "cache_tile_responses")
+            twms.twms.config.cache_tile_responses = {
+                ("EPSG:3857", ("transparent",), (), 256, 256, (), "PNG"): (
+                    cache_root,
+                    "png",
+                ),
+            }
+            try:
+                status, content_type, body = twms.twms.twms_main(
+                    {
+                        "request": "GetTile",
+                        "layers": "transparent",
+                        "format": "image/png",
+                        "z": "2",
+                        "x": "3",
+                        "y": "4",
+                    }
+                )
+
+                path = os.path.join(cache_root, "2", "3", "4.png")
+                self.assertEqual(status, 200)
+                self.assertEqual(content_type, "image/png")
+                self.assertIsInstance(body, bytes)
+                with open(path, "rb") as cached_tile:
+                    self.assertEqual(cached_tile.read(), body)
+                with Image.open(path) as image:
+                    self.assertEqual(image.size, (256, 256))
+            finally:
+                if had_cache:
+                    twms.twms.config.cache_tile_responses = old_cache
+                else:
+                    del twms.twms.config.cache_tile_responses
+
     def test_tile_cache_can_use_zxy_layout(self):
         with tempfile.TemporaryDirectory() as cache_root:
             old_cache = twms.fetchers.config.tiles_cache

--- a/tests/test_legacy_smoke.py
+++ b/tests/test_legacy_smoke.py
@@ -553,6 +553,70 @@ class LegacySmokeTest(unittest.TestCase):
             finally:
                 twms.fetchers.config.tiles_cache = old_cache
 
+    def test_legacy_percent_tile_template_still_uses_transform_tuple(self):
+        with tempfile.TemporaryDirectory() as cache_root:
+            old_cache = twms.fetchers.config.tiles_cache
+            twms.fetchers.config.tiles_cache = cache_root + os.sep
+            layer = {
+                "prefix": "url",
+                "ext": "png",
+                "remote_url": "http://example.test/%s/%s/%s.png",
+                "transform_tile_number": lambda z, x, y: (x, y, z - 1),
+            }
+            try:
+                with mock.patch("twms.fetchers.urlopen") as urlopen:
+                    urlopen.return_value.read.return_value = self.image_bytes(
+                        (1, 2, 3, 255)
+                    )
+                    twms.fetchers.Tile(2, 3, 4, layer)
+
+                urlopen.assert_called_once_with("http://example.test/3/4/1.png")
+            finally:
+                twms.fetchers.config.tiles_cache = old_cache
+
+    def test_named_tile_template_placeholders(self):
+        with tempfile.TemporaryDirectory() as cache_root:
+            old_cache = twms.fetchers.config.tiles_cache
+            twms.fetchers.config.tiles_cache = cache_root + os.sep
+            layer = {
+                "prefix": "url",
+                "ext": "png",
+                "remote_url": "http://example.test/{z}/{x}/{y}/{-y}/{q}.png",
+            }
+            try:
+                with mock.patch("twms.fetchers.urlopen") as urlopen:
+                    urlopen.return_value.read.return_value = self.image_bytes(
+                        (1, 2, 3, 255)
+                    )
+                    twms.fetchers.Tile(4, 9, 5, layer)
+
+                urlopen.assert_called_once_with(
+                    "http://example.test/4/9/5/10/1203.png"
+                )
+            finally:
+                twms.fetchers.config.tiles_cache = old_cache
+
+    def test_named_tile_template_uses_transform_tuple(self):
+        with tempfile.TemporaryDirectory() as cache_root:
+            old_cache = twms.fetchers.config.tiles_cache
+            twms.fetchers.config.tiles_cache = cache_root + os.sep
+            layer = {
+                "prefix": "url",
+                "ext": "png",
+                "remote_url": "http://example.test/z{z}/x{x}/y{y}.png",
+                "transform_tile_number": lambda z, x, y: (z - 1, x + 1, y + 2),
+            }
+            try:
+                with mock.patch("twms.fetchers.urlopen") as urlopen:
+                    urlopen.return_value.read.return_value = self.image_bytes(
+                        (1, 2, 3, 255)
+                    )
+                    twms.fetchers.Tile(4, 5, 6, layer)
+
+                urlopen.assert_called_once_with("http://example.test/z3/x6/y8.png")
+            finally:
+                twms.fetchers.config.tiles_cache = old_cache
+
     def test_wsgi_application_imports(self):
         self.assertTrue(callable(twms.daemon.application))
 

--- a/tests/test_legacy_smoke.py
+++ b/tests/test_legacy_smoke.py
@@ -573,6 +573,66 @@ class LegacySmokeTest(unittest.TestCase):
             finally:
                 twms.fetchers.config.tiles_cache = old_cache
 
+    def test_tile_fetcher_sends_configured_headers(self):
+        with tempfile.TemporaryDirectory() as cache_root:
+            old_cache = twms.fetchers.config.tiles_cache
+            twms.fetchers.config.tiles_cache = cache_root + os.sep
+            layer = {
+                "prefix": "headers",
+                "ext": "png",
+                "remote_url": "http://example.test/%s/%s/%s.png",
+                "headers": {
+                    "Referer": "https://example.test/map/",
+                    "User-Agent": "twms-test",
+                },
+            }
+            try:
+                with mock.patch("twms.fetchers.urlopen") as urlopen:
+                    urlopen.return_value.read.return_value = self.image_bytes(
+                        (1, 2, 3, 255)
+                    )
+                    twms.fetchers.Tile(2, 3, 4, layer)
+
+                request = urlopen.call_args.args[0]
+                headers = {
+                    key.lower(): value for key, value in request.header_items()
+                }
+                self.assertEqual(request.full_url, "http://example.test/2/3/4.png")
+                self.assertEqual(headers["referer"], "https://example.test/map/")
+                self.assertEqual(headers["user-agent"], "twms-test")
+            finally:
+                twms.fetchers.config.tiles_cache = old_cache
+
+    def test_wms_fetcher_sends_configured_headers(self):
+        with tempfile.TemporaryDirectory() as cache_root:
+            old_cache = twms.fetchers.config.tiles_cache
+            twms.fetchers.config.tiles_cache = cache_root + os.sep
+            layer = {
+                "prefix": "wms-headers",
+                "ext": "png",
+                "remote_url": "http://example.test/wms?",
+                "proj": "EPSG:3857",
+                "headers": {
+                    "Referer": "https://example.test/wms-client/",
+                },
+            }
+            try:
+                with mock.patch("twms.fetchers.urlopen") as urlopen:
+                    urlopen.return_value.read.return_value = self.image_bytes(
+                        (1, 2, 3, 255)
+                    )
+                    twms.fetchers.WMS(2, 3, 4, layer)
+
+                request = urlopen.call_args.args[0]
+                headers = {
+                    key.lower(): value for key, value in request.header_items()
+                }
+                self.assertTrue(request.full_url.startswith("http://example.test/wms?"))
+                self.assertIn("bbox=", request.full_url)
+                self.assertEqual(headers["referer"], "https://example.test/wms-client/")
+            finally:
+                twms.fetchers.config.tiles_cache = old_cache
+
     def test_configured_http_status_tile_is_recorded_as_tne(self):
         with tempfile.TemporaryDirectory() as cache_root:
             old_cache = twms.fetchers.config.tiles_cache

--- a/tests/test_legacy_smoke.py
+++ b/tests/test_legacy_smoke.py
@@ -1,22 +1,43 @@
 import importlib
 import importlib.metadata
+import hashlib
 import json
+import os
 from io import BytesIO
+import tempfile
 import threading
 import unittest
 import urllib.request
 from http.server import ThreadingHTTPServer
 import xml.etree.ElementTree as ET
+from unittest import mock
 
 from PIL import Image
 
 import twms
 import twms.daemon
+import twms.fetchers
 import twms.server
 import twms.twms
 
 
 class LegacySmokeTest(unittest.TestCase):
+    def image_bytes(self, color, image_format="PNG"):
+        buffer = BytesIO()
+        Image.new("RGBA", (256, 256), color).save(buffer, image_format)
+        return buffer.getvalue()
+
+    def cache_path(self, cache_root, layer, z, x, y):
+        return os.path.join(
+            cache_root,
+            layer["prefix"],
+            "z%s" % z,
+            "%s" % (x // 1024),
+            "x%s" % x,
+            "%s" % (y // 1024),
+            "y%s.%s" % (y, layer["ext"]),
+        )
+
     def test_public_version_keeps_keyboard_suffix(self):
         self.assertEqual(twms.__version__, "0.07z")
         self.assertEqual(importlib.metadata.version("twms"), "0.7+z")
@@ -152,6 +173,116 @@ class LegacySmokeTest(unittest.TestCase):
         with Image.open(BytesIO(body)) as image:
             self.assertEqual(image.size, (256, 256))
             self.assertEqual(image.mode, "RGBA")
+
+    def test_tile_cache_uses_fresh_file_without_network(self):
+        with tempfile.TemporaryDirectory() as cache_root:
+            old_cache = twms.fetchers.config.tiles_cache
+            twms.fetchers.config.tiles_cache = cache_root + os.sep
+            layer = {
+                "prefix": "ttl",
+                "ext": "png",
+                "remote_url": "http://example.test/%s/%s/%s.png",
+                "cache_ttl": 3600,
+            }
+            try:
+                path = self.cache_path(cache_root, layer, 2, 3, 4)
+                os.makedirs(os.path.dirname(path))
+                with open(path, "wb") as cached_tile:
+                    cached_tile.write(self.image_bytes((10, 20, 30, 255)))
+
+                with mock.patch("twms.fetchers.urlopen") as urlopen:
+                    image = twms.fetchers.Tile(2, 3, 4, layer)
+
+                urlopen.assert_not_called()
+                self.assertEqual(image.getpixel((0, 0)), (10, 20, 30, 255))
+            finally:
+                twms.fetchers.config.tiles_cache = old_cache
+
+    def test_tile_cache_refetches_expired_file_and_keeps_stale_on_error(self):
+        with tempfile.TemporaryDirectory() as cache_root:
+            old_cache = twms.fetchers.config.tiles_cache
+            twms.fetchers.config.tiles_cache = cache_root + os.sep
+            layer = {
+                "prefix": "ttl",
+                "ext": "png",
+                "remote_url": "http://example.test/%s/%s/%s.png",
+                "cache_ttl": 1,
+            }
+            try:
+                path = self.cache_path(cache_root, layer, 2, 3, 4)
+                os.makedirs(os.path.dirname(path))
+                with open(path, "wb") as cached_tile:
+                    cached_tile.write(self.image_bytes((10, 20, 30, 255)))
+                old_time = 946684800
+                os.utime(path, (old_time, old_time))
+
+                with mock.patch("twms.fetchers.urlopen") as urlopen:
+                    urlopen.return_value.read.return_value = self.image_bytes(
+                        (40, 50, 60, 255)
+                    )
+                    image = twms.fetchers.Tile(2, 3, 4, layer)
+
+                urlopen.assert_called_once()
+                self.assertEqual(image.getpixel((0, 0)), (40, 50, 60, 255))
+
+                os.utime(path, (old_time, old_time))
+                with mock.patch("twms.fetchers.urlopen", side_effect=OSError):
+                    image = twms.fetchers.Tile(2, 3, 4, layer)
+
+                self.assertEqual(image.getpixel((0, 0)), (40, 50, 60, 255))
+            finally:
+                twms.fetchers.config.tiles_cache = old_cache
+
+    def test_tile_cache_tne_suppresses_fetch_until_ttl_expires(self):
+        with tempfile.TemporaryDirectory() as cache_root:
+            old_cache = twms.fetchers.config.tiles_cache
+            twms.fetchers.config.tiles_cache = cache_root + os.sep
+            layer = {
+                "prefix": "ttl",
+                "ext": "png",
+                "remote_url": "http://example.test/%s/%s/%s.png",
+                "cache_ttl": 3600,
+            }
+            try:
+                path = self.cache_path(cache_root, layer, 2, 3, 4)
+                tne_path = path[:-3] + "tne"
+                os.makedirs(os.path.dirname(tne_path))
+                open(tne_path, "wb").close()
+
+                with mock.patch("twms.fetchers.urlopen") as urlopen:
+                    image = twms.fetchers.Tile(2, 3, 4, layer)
+
+                urlopen.assert_not_called()
+                self.assertIsNone(image)
+            finally:
+                twms.fetchers.config.tiles_cache = old_cache
+
+    def test_dead_tile_dict_is_recorded_as_tne(self):
+        with tempfile.TemporaryDirectory() as cache_root:
+            old_cache = twms.fetchers.config.tiles_cache
+            twms.fetchers.config.tiles_cache = cache_root + os.sep
+            body = self.image_bytes((255, 0, 0, 255))
+            layer = {
+                "prefix": "dead",
+                "ext": "png",
+                "remote_url": "http://example.test/%s/%s/%s.png",
+                "dead_tile": {
+                    "size": len(body),
+                    "md5": {hashlib.md5(body).hexdigest()},
+                },
+            }
+            try:
+                path = self.cache_path(cache_root, layer, 2, 3, 4)
+                tne_path = path[:-3] + "tne"
+                with mock.patch("twms.fetchers.urlopen") as urlopen:
+                    urlopen.return_value.read.return_value = body
+                    image = twms.fetchers.Tile(2, 3, 4, layer)
+
+                self.assertFalse(image)
+                self.assertFalse(os.path.exists(path))
+                self.assertTrue(os.path.exists(tne_path))
+            finally:
+                twms.fetchers.config.tiles_cache = old_cache
 
     def test_wsgi_application_imports(self):
         self.assertTrue(callable(twms.daemon.application))

--- a/tests/test_legacy_smoke.py
+++ b/tests/test_legacy_smoke.py
@@ -395,13 +395,82 @@ class LegacySmokeTest(unittest.TestCase):
         self.assertEqual(status, 200)
         self.assertEqual(content_type, "text/xml")
         self.assertEqual(root.tag, "{http://josm.openstreetmap.de/maps-1.0}imagery")
+        self.assertEqual(osm.find("josm:default", namespaces).text, "true")
         self.assertEqual(osm.find("josm:name", namespaces).text, "OpenStreetMap mapnik")
         self.assertEqual(osm.find("josm:type", namespaces).text, "tms")
         self.assertEqual(
             osm.find("josm:url", namespaces).text,
             "http://example.test/osm/{zoom}/{x}/{y}.png",
         )
+        self.assertEqual(
+            osm.find("josm:description", namespaces).text,
+            "OpenStreetMap mapnik",
+        )
+        self.assertEqual(osm.find("josm:valid-georeference", namespaces).text, "true")
         self.assertEqual(landsat.find("josm:max-zoom", namespaces).text, "11")
+
+    def test_josm_imagery_xml_layer_metadata(self):
+        old_layers = twms.twms.config.layers
+        twms.twms.config.layers = {
+            "metadata": {
+                "name": "Metadata",
+                "prefix": "metadata",
+                "ext": "png",
+                "proj": "EPSG:3857",
+                "bounds": (1.0, 2.0, 3.0, 4.0),
+                "overlay": True,
+                "provider_url": "http://provider.example/",
+                "dead_tile": {
+                    "md5": {
+                        "11111111111111111111111111111111",
+                        "22222222222222222222222222222222",
+                    },
+                },
+                "min_zoom": 3,
+                "max_zoom": 7,
+            }
+        }
+        try:
+            status, content_type, body = twms.twms.twms_main(
+                {
+                    "request": "GetJOSMImagery",
+                    "ref": "http://example.test/",
+                }
+            )
+
+            namespaces = {"josm": "http://josm.openstreetmap.de/maps-1.0"}
+            root = ET.fromstring(body)
+            entry = root.find("./josm:entry[josm:id='twms-metadata']", namespaces)
+            bounds = entry.find("josm:bounds", namespaces)
+            checksums = entry.findall("josm:no-tile-checksum", namespaces)
+
+            self.assertEqual(status, 200)
+            self.assertEqual(content_type, "text/xml")
+            self.assertEqual(entry.attrib["overlay"], "true")
+            self.assertEqual(
+                entry.find("josm:attribution-url", namespaces).text,
+                "http://provider.example/",
+            )
+            self.assertEqual(
+                bounds.attrib,
+                {
+                    "min-lon": "1.0",
+                    "min-lat": "2.0",
+                    "max-lon": "3.0",
+                    "max-lat": "4.0",
+                },
+            )
+            self.assertEqual(
+                [(item.attrib["type"], item.attrib["value"]) for item in checksums],
+                [
+                    ("MD5", "11111111111111111111111111111111"),
+                    ("MD5", "22222222222222222222222222222222"),
+                ],
+            )
+            self.assertEqual(entry.find("josm:min-zoom", namespaces).text, "3")
+            self.assertEqual(entry.find("josm:max-zoom", namespaces).text, "6")
+        finally:
+            twms.twms.config.layers = old_layers
 
     def test_wmts_capabilities_smoke(self):
         status, content_type, body = twms.twms.twms_main(

--- a/tests/test_legacy_smoke.py
+++ b/tests/test_legacy_smoke.py
@@ -717,6 +717,61 @@ class LegacySmokeTest(unittest.TestCase):
             finally:
                 twms.fetchers.config.tiles_cache = old_cache
 
+    def test_tile_fetch_retries_transient_upstream_error(self):
+        with tempfile.TemporaryDirectory() as cache_root:
+            old_cache = twms.fetchers.config.tiles_cache
+            twms.fetchers.config.tiles_cache = cache_root + os.sep
+            layer = {
+                "prefix": "retry",
+                "ext": "png",
+                "remote_url": "http://example.test/%s/%s/%s.png",
+                "upstream_retries": 2,
+            }
+            try:
+                path = self.cache_path(cache_root, layer, 2, 3, 4)
+                response = mock.Mock()
+                response.read.return_value = self.image_bytes((11, 22, 33, 255))
+                with mock.patch(
+                    "twms.fetchers.urlopen",
+                    side_effect=[OSError("temporary"), response],
+                ) as urlopen:
+                    image = twms.fetchers.Tile(2, 3, 4, layer)
+
+                self.assertEqual(urlopen.call_count, 2)
+                self.assertEqual(image.getpixel((0, 0)), (11, 22, 33, 255))
+                self.assertTrue(os.path.exists(path))
+            finally:
+                twms.fetchers.config.tiles_cache = old_cache
+
+    def test_tile_fetch_does_not_retry_http_tne_status(self):
+        with tempfile.TemporaryDirectory() as cache_root:
+            old_cache = twms.fetchers.config.tiles_cache
+            twms.fetchers.config.tiles_cache = cache_root + os.sep
+            layer = {
+                "prefix": "retry-http-tne",
+                "ext": "png",
+                "remote_url": "http://example.test/%s/%s/%s.png",
+                "upstream_retries": 3,
+            }
+            try:
+                path = self.cache_path(cache_root, layer, 2, 3, 4)
+                tne_path = path[:-3] + "tne"
+                error = urllib.error.HTTPError(
+                    url="http://example.test/2/3/4.png",
+                    code=404,
+                    msg="Not Found",
+                    hdrs={},
+                    fp=None,
+                )
+                with mock.patch("twms.fetchers.urlopen", side_effect=error) as urlopen:
+                    image = twms.fetchers.Tile(2, 3, 4, layer)
+
+                urlopen.assert_called_once()
+                self.assertFalse(image)
+                self.assertTrue(os.path.exists(tne_path))
+            finally:
+                twms.fetchers.config.tiles_cache = old_cache
+
     def test_tile_cache_tne_suppresses_fetch_until_ttl_expires(self):
         with tempfile.TemporaryDirectory() as cache_root:
             old_cache = twms.fetchers.config.tiles_cache

--- a/tests/test_legacy_smoke.py
+++ b/tests/test_legacy_smoke.py
@@ -624,12 +624,86 @@ class LegacySmokeTest(unittest.TestCase):
                 else:
                     del twms.twms.config.cache_tile_responses
 
+    def test_legacy_response_cache_accepts_mime_format_key(self):
+        with tempfile.TemporaryDirectory() as cache_root:
+            old_cache = getattr(twms.twms.config, "cache_tile_responses", None)
+            had_cache = hasattr(twms.twms.config, "cache_tile_responses")
+            twms.twms.config.cache_tile_responses = {
+                ("EPSG:3857", ("transparent",), (), 256, 256, (), "image/png"): (
+                    cache_root,
+                    "png",
+                ),
+            }
+            try:
+                path = os.path.join(cache_root, "2", "3", "4.png")
+                os.makedirs(os.path.dirname(path))
+                with open(path, "wb") as cached_tile:
+                    cached_tile.write(self.image_bytes((12, 34, 56, 255)))
+
+                status, content_type, body = twms.twms.twms_main(
+                    {
+                        "request": "GetTile",
+                        "layers": "transparent",
+                        "format": "image/png",
+                        "z": "2",
+                        "x": "3",
+                        "y": "4",
+                    }
+                )
+
+                self.assertEqual(status, 200)
+                self.assertEqual(content_type, "image/png")
+                self.assertIsInstance(body, bytes)
+                with Image.open(BytesIO(body)) as image:
+                    self.assertEqual(image.getpixel((0, 0)), (12, 34, 56, 255))
+            finally:
+                if had_cache:
+                    twms.twms.config.cache_tile_responses = old_cache
+                else:
+                    del twms.twms.config.cache_tile_responses
+
     def test_legacy_response_cache_writes_binary_tile(self):
         with tempfile.TemporaryDirectory() as cache_root:
             old_cache = getattr(twms.twms.config, "cache_tile_responses", None)
             had_cache = hasattr(twms.twms.config, "cache_tile_responses")
             twms.twms.config.cache_tile_responses = {
                 ("EPSG:3857", ("transparent",), (), 256, 256, (), "PNG"): (
+                    cache_root,
+                    "png",
+                ),
+            }
+            try:
+                status, content_type, body = twms.twms.twms_main(
+                    {
+                        "request": "GetTile",
+                        "layers": "transparent",
+                        "format": "image/png",
+                        "z": "2",
+                        "x": "3",
+                        "y": "4",
+                    }
+                )
+
+                path = os.path.join(cache_root, "2", "3", "4.png")
+                self.assertEqual(status, 200)
+                self.assertEqual(content_type, "image/png")
+                self.assertIsInstance(body, bytes)
+                with open(path, "rb") as cached_tile:
+                    self.assertEqual(cached_tile.read(), body)
+                with Image.open(path) as image:
+                    self.assertEqual(image.size, (256, 256))
+            finally:
+                if had_cache:
+                    twms.twms.config.cache_tile_responses = old_cache
+                else:
+                    del twms.twms.config.cache_tile_responses
+
+    def test_legacy_response_cache_writes_mime_format_key(self):
+        with tempfile.TemporaryDirectory() as cache_root:
+            old_cache = getattr(twms.twms.config, "cache_tile_responses", None)
+            had_cache = hasattr(twms.twms.config, "cache_tile_responses")
+            twms.twms.config.cache_tile_responses = {
+                ("EPSG:3857", ("transparent",), (), 256, 256, (), "image/png"): (
                     cache_root,
                     "png",
                 ),

--- a/tests/test_legacy_smoke.py
+++ b/tests/test_legacy_smoke.py
@@ -112,6 +112,7 @@ class LegacySmokeTest(unittest.TestCase):
         self.assertEqual(content_type, "application/vnd.ogc.wms_xml")
         self.assertIn("<WMT_MS_Capabilities", body)
         self.assertIn("OpenStreetMap mapnik", body)
+        self.assertIn("<Format>image/webp</Format>", body)
         self.assertNotIn("<SRS>CRS:84</SRS>", body)
 
     def test_wms_130_capabilities_smoke(self):
@@ -159,6 +160,25 @@ class LegacySmokeTest(unittest.TestCase):
         self.assertEqual(status, 200)
         self.assertEqual(content_type, "image/png")
         with Image.open(BytesIO(body)) as image:
+            self.assertEqual(image.size, (32, 32))
+
+    def test_wms_getmap_accepts_webp_format(self):
+        status, content_type, body = twms.twms.twms_main(
+            {
+                "request": "GetMap",
+                "layers": "transparent",
+                "format": "image/webp",
+                "width": "32",
+                "height": "32",
+                "srs": "EPSG:3857",
+                "bbox": "-1,-1,1,1",
+            }
+        )
+
+        self.assertEqual(status, 200)
+        self.assertEqual(content_type, "image/webp")
+        with Image.open(BytesIO(body)) as image:
+            self.assertEqual(image.format, "WEBP")
             self.assertEqual(image.size, (32, 32))
 
     def test_overview_smoke(self):

--- a/tests/test_legacy_smoke.py
+++ b/tests/test_legacy_smoke.py
@@ -976,6 +976,22 @@ class LegacySmokeTest(unittest.TestCase):
                 with Image.open(BytesIO(body)) as image:
                     self.assertEqual(image.size, (256, 256))
                     self.assertEqual(image.mode, "RGBA")
+
+            with urllib.request.urlopen(
+                base + "/wmts/transparent/0/0/0.png?cache=1"
+            ) as response:
+                body = response.read()
+                self.assertEqual(response.status, 200)
+                self.assertIn("image/png", response.headers["Content-Type"])
+                with Image.open(BytesIO(body)) as image:
+                    self.assertEqual(image.size, (256, 256))
+                    self.assertEqual(image.mode, "RGBA")
+
+            for path in ("/wmts", "/tilejson/.json", "/does-not-exist"):
+                with self.subTest(path=path):
+                    with self.assertRaises(urllib.error.HTTPError) as error:
+                        urllib.request.urlopen(base + path)
+                    self.assertEqual(error.exception.code, 404)
         finally:
             httpd.shutdown()
             httpd.server_close()

--- a/tests/test_legacy_smoke.py
+++ b/tests/test_legacy_smoke.py
@@ -1,0 +1,59 @@
+import importlib
+import importlib.metadata
+import unittest
+
+import twms
+import twms.daemon
+import twms.twms
+
+
+class LegacySmokeTest(unittest.TestCase):
+    def test_public_version_keeps_keyboard_suffix(self):
+        self.assertEqual(twms.__version__, "0.07z")
+        self.assertEqual(importlib.metadata.version("twms"), "0.7+z")
+
+    def test_legacy_modules_import_as_package_modules(self):
+        modules = [
+            "twms.bbox",
+            "twms.capabilities",
+            "twms.correctify",
+            "twms.drawing",
+            "twms.filter",
+            "twms.gpxparse",
+            "twms.overview",
+            "twms.projections",
+            "twms.reproject",
+            "twms.sketch",
+        ]
+        for module in modules:
+            with self.subTest(module=module):
+                importlib.import_module(module)
+
+    def test_wms_capabilities_smoke(self):
+        status, content_type, body = twms.twms.twms_main(
+            {
+                "request": "GetCapabilities",
+                "version": "1.1.1",
+                "ref": "http://example.test/wms",
+            }
+        )
+
+        self.assertEqual(status, 200)
+        self.assertEqual(content_type, "application/vnd.ogc.wms_xml")
+        self.assertIn("<WMT_MS_Capabilities", body)
+        self.assertIn("OpenStreetMap mapnik", body)
+
+    def test_overview_smoke(self):
+        status, content_type, body = twms.twms.twms_main({"ref": "http://example.test/"})
+
+        self.assertEqual(status, 200)
+        self.assertEqual(content_type, "text/html")
+        self.assertIn("<table>", body)
+        self.assertIn("Yandex Satellite", body)
+
+    def test_wsgi_application_imports(self):
+        self.assertTrue(callable(twms.daemon.application))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_legacy_smoke.py
+++ b/tests/test_legacy_smoke.py
@@ -152,6 +152,38 @@ class LegacySmokeTest(unittest.TestCase):
         self.assertIn("<table>", body)
         self.assertIn("Yandex Satellite", body)
 
+    def test_overview_accepts_bounds_alias_and_provider_link(self):
+        old_config_layers = twms.twms.config.layers
+        old_overview_layers = twms.twms.overview.layers
+        layers = {
+            "bounded": {
+                "name": "Bounded",
+                "prefix": "bounded",
+                "ext": "png",
+                "proj": "EPSG:3857",
+                "bounds": (1.0, 2.0, 3.0, 4.0),
+                "provider_url": "http://provider.example/",
+            }
+        }
+        twms.twms.config.layers = layers
+        twms.twms.overview.layers = layers
+        try:
+            status, content_type, body = twms.twms.twms_main(
+                {"ref": "http://example.test/"}
+            )
+
+            self.assertEqual(status, 200)
+            self.assertEqual(content_type, "text/html")
+            self.assertIn("bbox=1.0,2.0,3.0,4.0", body)
+            self.assertIn(
+                '<a referrerpolicy="no-referrer" href="http://provider.example/">'
+                "Bounded</a>",
+                body,
+            )
+        finally:
+            twms.twms.config.layers = old_config_layers
+            twms.twms.overview.layers = old_overview_layers
+
     def test_gettile_transparent_layer_smoke(self):
         status, content_type, body = twms.twms.twms_main(
             {

--- a/tests/test_legacy_smoke.py
+++ b/tests/test_legacy_smoke.py
@@ -1,12 +1,16 @@
 import importlib
 import importlib.metadata
 from io import BytesIO
+import threading
 import unittest
+import urllib.request
+from http.server import ThreadingHTTPServer
 
 from PIL import Image
 
 import twms
 import twms.daemon
+import twms.server
 import twms.twms
 
 
@@ -74,6 +78,33 @@ class LegacySmokeTest(unittest.TestCase):
 
     def test_wsgi_application_imports(self):
         self.assertTrue(callable(twms.daemon.application))
+
+    def test_stdlib_server_serves_wms_and_gettile(self):
+        httpd = ThreadingHTTPServer(("127.0.0.1", 0), twms.server.TWMSRequestHandler)
+        thread = threading.Thread(target=httpd.serve_forever)
+        thread.daemon = True
+        thread.start()
+        base = "http://127.0.0.1:%s" % httpd.server_address[1]
+        try:
+            with urllib.request.urlopen(
+                base + "/?request=GetCapabilities&version=1.1.1"
+            ) as response:
+                body = response.read().decode("utf-8")
+                self.assertEqual(response.status, 200)
+                self.assertIn("application/vnd.ogc.wms_xml", response.headers["Content-Type"])
+                self.assertIn("<WMT_MS_Capabilities", body)
+
+            with urllib.request.urlopen(base + "/transparent/0/0/0.png") as response:
+                body = response.read()
+                self.assertEqual(response.status, 200)
+                self.assertIn("image/png", response.headers["Content-Type"])
+                with Image.open(BytesIO(body)) as image:
+                    self.assertEqual(image.size, (256, 256))
+                    self.assertEqual(image.mode, "RGBA")
+        finally:
+            httpd.shutdown()
+            httpd.server_close()
+            thread.join()
 
 
 if __name__ == "__main__":

--- a/tests/test_legacy_smoke.py
+++ b/tests/test_legacy_smoke.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import math
 import os
+from collections import OrderedDict
 from io import BytesIO
 import tempfile
 import threading
@@ -520,6 +521,33 @@ class LegacySmokeTest(unittest.TestCase):
                 self.assertEqual(image.getpixel((0, 0)), (10, 20, 30, 255))
             finally:
                 twms.twms.config.tiles_cache = old_cache
+
+    def test_legacy_ram_cache_is_lru_bounded(self):
+        old_cached_objs = twms.twms.cached_objs
+        old_limit = twms.twms.config.max_ram_cached_tiles
+        twms.twms.cached_objs = OrderedDict()
+        twms.twms.config.max_ram_cached_tiles = 2
+        layer = {"prefix": "ram"}
+        first = Image.new("RGBA", (1, 1), (1, 1, 1, 255))
+        second = Image.new("RGBA", (1, 1), (2, 2, 2, 255))
+        third = Image.new("RGBA", (1, 1), (3, 3, 3, 255))
+        try:
+            first_key = twms.twms._ram_cache_key(layer, 1, 1, 1)
+            second_key = twms.twms._ram_cache_key(layer, 1, 2, 2)
+            third_key = twms.twms._ram_cache_key(layer, 1, 3, 3)
+            twms.twms._ram_cache_put(first_key, first)
+            twms.twms._ram_cache_put(second_key, second)
+
+            self.assertIs(twms.twms._ram_cache_get(first_key), first)
+
+            twms.twms._ram_cache_put(third_key, third)
+
+            self.assertIn(first_key, twms.twms.cached_objs)
+            self.assertNotIn(second_key, twms.twms.cached_objs)
+            self.assertIn(third_key, twms.twms.cached_objs)
+        finally:
+            twms.twms.cached_objs = old_cached_objs
+            twms.twms.config.max_ram_cached_tiles = old_limit
 
     def test_legacy_gettile_fast_cache_reads_binary_tile(self):
         with tempfile.TemporaryDirectory() as cache_root:

--- a/tests/test_legacy_smoke.py
+++ b/tests/test_legacy_smoke.py
@@ -2,12 +2,14 @@ import importlib
 import importlib.metadata
 import hashlib
 import json
+import math
 import os
 from io import BytesIO
 import tempfile
 import threading
 import unittest
 import urllib.request
+import warnings
 from http.server import ThreadingHTTPServer
 import xml.etree.ElementTree as ET
 from unittest import mock
@@ -17,6 +19,7 @@ from PIL import Image
 import twms
 import twms.daemon
 import twms.fetchers
+import twms.projections
 import twms.server
 import twms.twms
 
@@ -173,6 +176,42 @@ class LegacySmokeTest(unittest.TestCase):
         with Image.open(BytesIO(body)) as image:
             self.assertEqual(image.size, (256, 256))
             self.assertEqual(image.mode, "RGBA")
+
+    def test_webmercator_projection_clamps_poles(self):
+        maxbounds = 6378137 * math.pi
+
+        projected = twms.projections.from4326(
+            (-180.0, -90.0, 180.0, 90.0),
+            "EPSG:3857",
+        )
+
+        self.assertEqual(projected[0], -maxbounds)
+        self.assertEqual(projected[1], -maxbounds)
+        self.assertEqual(projected[2], maxbounds)
+        self.assertEqual(projected[3], maxbounds)
+
+    def test_optional_pyproj_projection_uses_modern_transformer(self):
+        if not hasattr(twms.projections.pyproj, "Transformer"):
+            self.skipTest("pyproj extra is not installed")
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            point = twms.projections.from4326((27.6, 53.2), "EPSG:32635")
+
+        self.assertTrue(540000 < point[0] < 541000)
+        self.assertTrue(5894000 < point[1] < 5895000)
+        self.assertFalse(
+            [warning for warning in caught if warning.category is FutureWarning],
+        )
+
+    def test_non_core_projection_reports_missing_pyproj_extra(self):
+        if hasattr(twms.projections.pyproj, "Transformer"):
+            self.skipTest("pyproj extra is installed")
+
+        with self.assertRaises(NotImplementedError) as raised:
+            twms.projections.from4326((27.6, 53.2), "EPSG:32635")
+
+        self.assertIn("twms[proj]", str(raised.exception))
 
     def test_tile_cache_uses_fresh_file_without_network(self):
         with tempfile.TemporaryDirectory() as cache_root:

--- a/tests/test_legacy_smoke.py
+++ b/tests/test_legacy_smoke.py
@@ -104,6 +104,36 @@ class LegacySmokeTest(unittest.TestCase):
         self.assertEqual(override.get("mimetype"), "image/jpeg")
         self.assertEqual(override.get("ext"), "jpg")
 
+    def test_layer_metadata_accepts_string_fetch_aliases(self):
+        module = type("Config", (), {})()
+        module.layers = {
+            "tiles": {"fetch": "tms"},
+            "wms": {"fetch": "wms"},
+        }
+
+        twms.config_loader.normalize_layer_metadata(module)
+
+        self.assertIs(module.layers["tiles"]["fetch"], twms.fetchers.Tile)
+        self.assertIs(module.layers["wms"]["fetch"], twms.fetchers.WMS)
+
+    def test_layer_metadata_accepts_default_string_fetch_alias(self):
+        module = type("Config", (), {})()
+        module.layer_defaults = {"fetch": "wms"}
+        module.layers = {
+            "defaulted": {"name": "Defaulted", "prefix": "defaulted"},
+        }
+
+        twms.config_loader.normalize_layer_metadata(module)
+
+        self.assertIs(module.layers["defaulted"]["fetch"], twms.fetchers.WMS)
+
+    def test_layer_metadata_rejects_unknown_string_fetch_alias(self):
+        module = type("Config", (), {})()
+        module.layers = {"bad": {"fetch": "factory-factory"}}
+
+        with self.assertRaisesRegex(ValueError, "factory-factory"):
+            twms.config_loader.normalize_layer_metadata(module)
+
     def test_legacy_modules_import_as_package_modules(self):
         modules = [
             "twms.bbox",

--- a/tests/test_legacy_smoke.py
+++ b/tests/test_legacy_smoke.py
@@ -628,7 +628,7 @@ class LegacySmokeTest(unittest.TestCase):
 
                 self.assertEqual(image.getpixel((0, 0)), (1, 2, 3, 255))
                 self.assertTrue(os.path.exists(path))
-                urlopen.assert_called_once_with(mock.ANY)
+                urlopen.assert_called_once_with(mock.ANY, timeout=30)
             finally:
                 twms.fetchers.config.tiles_cache = old_cache
 
@@ -651,6 +651,7 @@ class LegacySmokeTest(unittest.TestCase):
 
                 url = urlopen.call_args.args[0]
                 self.assertIsInstance(url, str)
+                self.assertEqual(urlopen.call_args.kwargs["timeout"], 30)
                 self.assertTrue(url.startswith("http://example.test/wms?bbox="))
                 self.assertIn("&width=384&height=384&srs=EPSG:3857", url)
             finally:
@@ -678,6 +679,7 @@ class LegacySmokeTest(unittest.TestCase):
 
                 url = urlopen.call_args.args[0]
                 self.assertIsInstance(url, str)
+                self.assertEqual(urlopen.call_args.kwargs["timeout"], 30)
                 self.assertIn("WIDTH=384&HEIGHT=384&CRS=EPSG:3857&BBOX=", url)
                 self.assertNotIn("srs=EPSG:3857", url)
                 self.assertEqual(url.count("BBOX="), 1)
@@ -751,6 +753,7 @@ class LegacySmokeTest(unittest.TestCase):
                 headers = {
                     key.lower(): value for key, value in request.header_items()
                 }
+                self.assertEqual(urlopen.call_args.kwargs["timeout"], 30)
                 self.assertEqual(request.full_url, "http://example.test/2/3/4.png")
                 self.assertEqual(headers["referer"], "https://example.test/map/")
                 self.assertEqual(headers["user-agent"], "twms-test")
@@ -781,9 +784,34 @@ class LegacySmokeTest(unittest.TestCase):
                 headers = {
                     key.lower(): value for key, value in request.header_items()
                 }
+                self.assertEqual(urlopen.call_args.kwargs["timeout"], 30)
                 self.assertTrue(request.full_url.startswith("http://example.test/wms?"))
                 self.assertIn("bbox=", request.full_url)
                 self.assertEqual(headers["referer"], "https://example.test/wms-client/")
+            finally:
+                twms.fetchers.config.tiles_cache = old_cache
+
+    def test_tile_fetcher_uses_configured_layer_timeout(self):
+        with tempfile.TemporaryDirectory() as cache_root:
+            old_cache = twms.fetchers.config.tiles_cache
+            twms.fetchers.config.tiles_cache = cache_root + os.sep
+            layer = {
+                "prefix": "timeout",
+                "ext": "png",
+                "remote_url": "http://example.test/%s/%s/%s.png",
+                "timeout": 7,
+            }
+            try:
+                with mock.patch("twms.fetchers.urlopen") as urlopen:
+                    urlopen.return_value.read.return_value = self.image_bytes(
+                        (1, 2, 3, 255)
+                    )
+                    twms.fetchers.Tile(2, 3, 4, layer)
+
+                urlopen.assert_called_once_with(
+                    "http://example.test/2/3/4.png",
+                    timeout=7,
+                )
             finally:
                 twms.fetchers.config.tiles_cache = old_cache
 
@@ -833,7 +861,10 @@ class LegacySmokeTest(unittest.TestCase):
                     )
                     twms.fetchers.Tile(2, 3, 4, layer)
 
-                urlopen.assert_called_once_with("http://example.test/3/4/1.png")
+                urlopen.assert_called_once_with(
+                    "http://example.test/3/4/1.png",
+                    timeout=30,
+                )
             finally:
                 twms.fetchers.config.tiles_cache = old_cache
 
@@ -854,7 +885,8 @@ class LegacySmokeTest(unittest.TestCase):
                     twms.fetchers.Tile(4, 9, 5, layer)
 
                 urlopen.assert_called_once_with(
-                    "http://example.test/4/9/5/10/1203.png"
+                    "http://example.test/4/9/5/10/1203.png",
+                    timeout=30,
                 )
             finally:
                 twms.fetchers.config.tiles_cache = old_cache
@@ -876,7 +908,10 @@ class LegacySmokeTest(unittest.TestCase):
                     )
                     twms.fetchers.Tile(4, 5, 6, layer)
 
-                urlopen.assert_called_once_with("http://example.test/z3/x6/y8.png")
+                urlopen.assert_called_once_with(
+                    "http://example.test/z3/x6/y8.png",
+                    timeout=30,
+                )
             finally:
                 twms.fetchers.config.tiles_cache = old_cache
 

--- a/tests/test_legacy_smoke.py
+++ b/tests/test_legacy_smoke.py
@@ -1,3 +1,4 @@
+import datetime
 import importlib
 import importlib.metadata
 import hashlib
@@ -17,8 +18,10 @@ from unittest import mock
 from PIL import Image
 
 import twms
+import twms.canvas
 import twms.daemon
 import twms.fetchers
+import twms.filter
 import twms.projections
 import twms.server
 import twms.twms
@@ -53,6 +56,7 @@ class LegacySmokeTest(unittest.TestCase):
             "twms.drawing",
             "twms.filter",
             "twms.gpxparse",
+            "twms.image_compat",
             "twms.overview",
             "twms.projections",
             "twms.reproject",
@@ -150,6 +154,80 @@ class LegacySmokeTest(unittest.TestCase):
         with Image.open(BytesIO(body)) as image:
             self.assertEqual(image.size, (256, 256))
             self.assertEqual(image.mode, "RGBA")
+
+    def test_legacy_getcorrections_without_rectify_file(self):
+        status, content_type, body = twms.twms.twms_main(
+            {
+                "request": "GetCorrections",
+                "layers": "osm",
+                "points": "27.6,53.2",
+            }
+        )
+
+        self.assertEqual(status, 200)
+        self.assertEqual(content_type, "text/plain")
+        self.assertEqual(body, "27.6,53.2;\n")
+
+    def test_legacy_filter_smoke(self):
+        image = Image.new("RGBA", (2, 1), (10, 20, 30, 255))
+
+        filtered = twms.filter.raster(image, ("swaprb", "brightness:2"))
+
+        self.assertEqual(filtered.getpixel((0, 0)), (60, 40, 20, 255))
+
+    def test_legacy_wkt_drawing_without_color_parameter(self):
+        status, content_type, body = twms.twms.twms_main(
+            {
+                "request": "GetMap",
+                "layers": "transparent",
+                "format": "image/png",
+                "width": "32",
+                "height": "32",
+                "bbox": "-1,-1,1,1",
+                "wkt": "LINESTRING(-1 -1,1 1)",
+            }
+        )
+
+        self.assertEqual(status, 200)
+        self.assertEqual(content_type, "image/png")
+        with Image.open(BytesIO(body)) as image:
+            self.assertEqual(image.size, (32, 32))
+            self.assertTrue(
+                any(image.getchannel("A").tobytes()),
+                "WKT overlay should draw visible pixels",
+            )
+
+    def test_legacy_canvas_blank_tile_smoke(self):
+        canvas = twms.canvas.WmsCanvas(tile_size=(32, 32))
+
+        canvas.FetchTile(0, 0)
+
+        self.assertEqual(canvas.tiles[(0, 0)]["im"].size, (32, 32))
+        self.assertEqual(canvas.tiles[(0, 0)]["im"].mode, "RGBA")
+
+    def test_getimg_resize_works_with_current_pillow(self):
+        tile = Image.new("RGBA", (256, 256), (1, 2, 3, 255))
+        tile.is_ok = True
+        layer = {
+            "name": "Resize smoke",
+            "prefix": "resize",
+            "proj": "EPSG:3857",
+            "cached": False,
+            "max_zoom": 1,
+        }
+
+        with mock.patch("twms.twms.tile_image", return_value=tile):
+            image = twms.twms.getimg(
+                (-1.0, -1.0, 1.0, 1.0),
+                "EPSG:3857",
+                (32, 32),
+                layer,
+                datetime.datetime.now(),
+                (),
+            )
+
+        self.assertEqual(image.size, (32, 32))
+        self.assertEqual(image.getpixel((0, 0)), (1, 2, 3, 255))
 
     def test_tilejson_smoke(self):
         status, content_type, body = twms.twms.twms_main(

--- a/tests/test_legacy_smoke.py
+++ b/tests/test_legacy_smoke.py
@@ -76,6 +76,54 @@ class LegacySmokeTest(unittest.TestCase):
         self.assertEqual(content_type, "application/vnd.ogc.wms_xml")
         self.assertIn("<WMT_MS_Capabilities", body)
         self.assertIn("OpenStreetMap mapnik", body)
+        self.assertNotIn("<SRS>CRS:84</SRS>", body)
+
+    def test_wms_130_capabilities_smoke(self):
+        status, content_type, body = twms.twms.twms_main(
+            {
+                "SERVICE": "WMS",
+                "REQUEST": "GetCapabilities",
+                "VERSION": "1.3.0",
+                "ref": "http://example.test/wms",
+            }
+        )
+
+        root = ET.fromstring(body)
+        namespaces = {"wms": "http://www.opengis.net/wms"}
+        osm = root.find(
+            "./wms:Capability/wms:Layer/wms:Layer[wms:Name='osm']",
+            namespaces,
+        )
+        crs_values = [element.text for element in osm.findall("wms:CRS", namespaces)]
+        bbox = osm.find("wms:BoundingBox", namespaces)
+
+        self.assertEqual(status, 200)
+        self.assertEqual(content_type, "text/xml")
+        self.assertEqual(root.tag, "{http://www.opengis.net/wms}WMS_Capabilities")
+        self.assertEqual(root.attrib["version"], "1.3.0")
+        self.assertIn("CRS:84", crs_values)
+        self.assertIn("EPSG:3857", crs_values)
+        self.assertEqual(bbox.attrib["CRS"], "EPSG:3857")
+        self.assertLess(float(bbox.attrib["minx"]), -20000000)
+        self.assertGreater(float(bbox.attrib["maxx"]), 20000000)
+
+    def test_wms_getmap_accepts_crs_parameter(self):
+        status, content_type, body = twms.twms.twms_main(
+            {
+                "request": "GetMap",
+                "layers": "transparent",
+                "format": "image/png",
+                "width": "32",
+                "height": "32",
+                "crs": "CRS:84",
+                "bbox": "-1,-1,1,1",
+            }
+        )
+
+        self.assertEqual(status, 200)
+        self.assertEqual(content_type, "image/png")
+        with Image.open(BytesIO(body)) as image:
+            self.assertEqual(image.size, (32, 32))
 
     def test_overview_smoke(self):
         status, content_type, body = twms.twms.twms_main({"ref": "http://example.test/"})

--- a/tests/test_legacy_smoke.py
+++ b/tests/test_legacy_smoke.py
@@ -9,6 +9,7 @@ from io import BytesIO
 import tempfile
 import threading
 import unittest
+import urllib.error
 import urllib.request
 import warnings
 from http.server import ThreadingHTTPServer
@@ -492,6 +493,63 @@ class LegacySmokeTest(unittest.TestCase):
                 self.assertEqual(image.format, "JPEG")
                 with Image.open(path) as cached_image:
                     self.assertEqual(cached_image.format, "PNG")
+            finally:
+                twms.fetchers.config.tiles_cache = old_cache
+
+    def test_http_404_tile_is_recorded_as_tne(self):
+        with tempfile.TemporaryDirectory() as cache_root:
+            old_cache = twms.fetchers.config.tiles_cache
+            twms.fetchers.config.tiles_cache = cache_root + os.sep
+            layer = {
+                "prefix": "http-tne",
+                "ext": "png",
+                "remote_url": "http://example.test/%s/%s/%s.png",
+            }
+            try:
+                path = self.cache_path(cache_root, layer, 2, 3, 4)
+                tne_path = path[:-3] + "tne"
+                error = urllib.error.HTTPError(
+                    "http://example.test/2/3/4.png",
+                    404,
+                    "Not Found",
+                    hdrs={},
+                    fp=None,
+                )
+                with mock.patch("twms.fetchers.urlopen", side_effect=error):
+                    image = twms.fetchers.Tile(2, 3, 4, layer)
+
+                self.assertFalse(image)
+                self.assertFalse(os.path.exists(path))
+                self.assertTrue(os.path.exists(tne_path))
+            finally:
+                twms.fetchers.config.tiles_cache = old_cache
+
+    def test_configured_http_status_tile_is_recorded_as_tne(self):
+        with tempfile.TemporaryDirectory() as cache_root:
+            old_cache = twms.fetchers.config.tiles_cache
+            twms.fetchers.config.tiles_cache = cache_root + os.sep
+            layer = {
+                "prefix": "http-tne",
+                "ext": "png",
+                "remote_url": "http://example.test/%s/%s/%s.png",
+                "dead_tile": {"http_status": 410},
+            }
+            try:
+                path = self.cache_path(cache_root, layer, 2, 3, 4)
+                tne_path = path[:-3] + "tne"
+                error = urllib.error.HTTPError(
+                    "http://example.test/2/3/4.png",
+                    410,
+                    "Gone",
+                    hdrs={},
+                    fp=None,
+                )
+                with mock.patch("twms.fetchers.urlopen", side_effect=error):
+                    image = twms.fetchers.Tile(2, 3, 4, layer)
+
+                self.assertFalse(image)
+                self.assertFalse(os.path.exists(path))
+                self.assertTrue(os.path.exists(tne_path))
             finally:
                 twms.fetchers.config.tiles_cache = old_cache
 

--- a/tests/test_legacy_smoke.py
+++ b/tests/test_legacy_smoke.py
@@ -1751,6 +1751,23 @@ class LegacySmokeTest(unittest.TestCase):
     def test_wsgi_application_imports(self):
         self.assertTrue(callable(twms.daemon.application))
 
+    def test_stdlib_server_startup_banner_lists_client_urls(self):
+        banner = twms.server.startup_banner("", 8080)
+
+        self.assertIn("TWMS server 0.07z listening on 0.0.0.0:8080", banner)
+        self.assertIn("Overview: http://127.0.0.1:8080/", banner)
+        self.assertIn(
+            "WMS: http://127.0.0.1:8080/wms?SERVICE=WMS&REQUEST=GetCapabilities",
+            banner,
+        )
+        self.assertIn(
+            "WMTS: http://127.0.0.1:8080/wmts/1.0.0/WMTSCapabilities.xml",
+            banner,
+        )
+        self.assertIn("JOSM imagery: http://127.0.0.1:8080/josm/maps.xml", banner)
+        self.assertNotIn("Cookie", banner)
+        self.assertNotIn("headers", banner.lower())
+
     def test_stdlib_server_serves_wms_and_gettile(self):
         httpd = ThreadingHTTPServer(("127.0.0.1", 0), twms.server.TWMSRequestHandler)
         thread = threading.Thread(target=httpd.serve_forever)
@@ -1763,6 +1780,7 @@ class LegacySmokeTest(unittest.TestCase):
             ) as response:
                 body = response.read().decode("utf-8")
                 self.assertEqual(response.status, 200)
+                self.assertIn("twms/0.07z", response.headers["Server"])
                 self.assertIn("application/vnd.ogc.wms_xml", response.headers["Content-Type"])
                 self.assertIn("<WMT_MS_Capabilities", body)
 

--- a/tests/test_legacy_smoke.py
+++ b/tests/test_legacy_smoke.py
@@ -219,6 +219,31 @@ class LegacySmokeTest(unittest.TestCase):
         self.assertEqual(canvas.tiles[(0, 0)]["im"].size, (32, 32))
         self.assertEqual(canvas.tiles[(0, 0)]["im"].mode, "RGBA")
 
+    def test_legacy_canvas_uses_default_upstream_timeout(self):
+        canvas = twms.canvas.WmsCanvas(
+            wms_url="http://example.test/wms?",
+            proj="EPSG:3857",
+        )
+
+        with mock.patch("twms.canvas.urlopen") as urlopen:
+            urlopen.return_value.read.return_value = self.image_bytes((1, 2, 3, 255))
+            canvas.FetchTile(0, 0)
+
+        urlopen.assert_called_once_with(mock.ANY, timeout=30)
+
+    def test_legacy_canvas_can_preserve_unbounded_upstream_wait(self):
+        canvas = twms.canvas.WmsCanvas(
+            wms_url="http://example.test/wms?",
+            proj="EPSG:3857",
+            timeout=None,
+        )
+
+        with mock.patch("twms.canvas.urlopen") as urlopen:
+            urlopen.return_value.read.return_value = self.image_bytes((1, 2, 3, 255))
+            canvas.FetchTile(0, 0)
+
+        urlopen.assert_called_once_with(mock.ANY, timeout=None)
+
     def test_getimg_resize_works_with_current_pillow(self):
         tile = Image.new("RGBA", (256, 256), (1, 2, 3, 255))
         tile.is_ok = True

--- a/tests/test_legacy_smoke.py
+++ b/tests/test_legacy_smoke.py
@@ -1766,7 +1766,23 @@ class LegacySmokeTest(unittest.TestCase):
                 self.assertIn("application/vnd.ogc.wms_xml", response.headers["Content-Type"])
                 self.assertIn("<WMT_MS_Capabilities", body)
 
+            with urllib.request.urlopen(
+                base + "/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.1.1"
+            ) as response:
+                body = response.read().decode("utf-8")
+                self.assertEqual(response.status, 200)
+                self.assertIn("application/vnd.ogc.wms_xml", response.headers["Content-Type"])
+                self.assertIn('xlink:href="' + base + '/wms?"', body)
+
             with urllib.request.urlopen(base + "/transparent/0/0/0.png") as response:
+                body = response.read()
+                self.assertEqual(response.status, 200)
+                self.assertIn("image/png", response.headers["Content-Type"])
+                with Image.open(BytesIO(body)) as image:
+                    self.assertEqual(image.size, (256, 256))
+                    self.assertEqual(image.mode, "RGBA")
+
+            with urllib.request.urlopen(base + "/wms/transparent/0/0/0.png") as response:
                 body = response.read()
                 self.assertEqual(response.status, 200)
                 self.assertIn("image/png", response.headers["Content-Type"])
@@ -1781,6 +1797,17 @@ class LegacySmokeTest(unittest.TestCase):
                 self.assertEqual(doc["tiles"], [base + "/osm/{z}/{x}/{y}.png"])
 
             with urllib.request.urlopen(base + "/josm/imagery.xml") as response:
+                root = ET.fromstring(response.read().decode("utf-8"))
+                namespaces = {"josm": "http://josm.openstreetmap.de/maps-1.0"}
+                osm = root.find("./josm:entry[josm:id='twms-osm']", namespaces)
+                self.assertEqual(response.status, 200)
+                self.assertIn("text/xml", response.headers["Content-Type"])
+                self.assertEqual(
+                    osm.find("josm:url", namespaces).text,
+                    base + "/osm/{zoom}/{x}/{y}.png",
+                )
+
+            with urllib.request.urlopen(base + "/josm/maps.xml") as response:
                 root = ET.fromstring(response.read().decode("utf-8"))
                 namespaces = {"josm": "http://josm.openstreetmap.de/maps-1.0"}
                 osm = root.find("./josm:entry[josm:id='twms-osm']", namespaces)

--- a/tests/test_legacy_smoke.py
+++ b/tests/test_legacy_smoke.py
@@ -30,7 +30,10 @@ import twms.twms
 class LegacySmokeTest(unittest.TestCase):
     def image_bytes(self, color, image_format="PNG"):
         buffer = BytesIO()
-        Image.new("RGBA", (256, 256), color).save(buffer, image_format)
+        image = Image.new("RGBA", (256, 256), color)
+        if image_format == "JPEG":
+            image = image.convert("RGB")
+        image.save(buffer, image_format)
         return buffer.getvalue()
 
     def cache_path(self, cache_root, layer, z, x, y):
@@ -446,6 +449,49 @@ class LegacySmokeTest(unittest.TestCase):
                 self.assertFalse(image)
                 self.assertFalse(os.path.exists(path))
                 self.assertTrue(os.path.exists(tne_path))
+            finally:
+                twms.fetchers.config.tiles_cache = old_cache
+
+    def test_invalid_downloaded_tile_is_not_cached(self):
+        with tempfile.TemporaryDirectory() as cache_root:
+            old_cache = twms.fetchers.config.tiles_cache
+            twms.fetchers.config.tiles_cache = cache_root + os.sep
+            layer = {
+                "prefix": "invalid",
+                "ext": "png",
+                "remote_url": "http://example.test/%s/%s/%s.png",
+            }
+            try:
+                path = self.cache_path(cache_root, layer, 2, 3, 4)
+                with mock.patch("twms.fetchers.urlopen") as urlopen:
+                    urlopen.return_value.read.return_value = b"not an image"
+                    image = twms.fetchers.Tile(2, 3, 4, layer)
+
+                self.assertFalse(image)
+                self.assertFalse(os.path.exists(path))
+            finally:
+                twms.fetchers.config.tiles_cache = old_cache
+
+    def test_tile_cache_converts_download_to_layer_extension(self):
+        with tempfile.TemporaryDirectory() as cache_root:
+            old_cache = twms.fetchers.config.tiles_cache
+            twms.fetchers.config.tiles_cache = cache_root + os.sep
+            layer = {
+                "prefix": "format",
+                "ext": "png",
+                "remote_url": "http://example.test/%s/%s/%s.jpg",
+            }
+            try:
+                path = self.cache_path(cache_root, layer, 2, 3, 4)
+                with mock.patch("twms.fetchers.urlopen") as urlopen:
+                    urlopen.return_value.read.return_value = self.image_bytes(
+                        (20, 30, 40), image_format="JPEG"
+                    )
+                    image = twms.fetchers.Tile(2, 3, 4, layer)
+
+                self.assertEqual(image.format, "JPEG")
+                with Image.open(path) as cached_image:
+                    self.assertEqual(cached_image.format, "PNG")
             finally:
                 twms.fetchers.config.tiles_cache = old_cache
 

--- a/tests/test_legacy_smoke.py
+++ b/tests/test_legacy_smoke.py
@@ -549,6 +549,30 @@ class LegacySmokeTest(unittest.TestCase):
             finally:
                 twms.fetchers.config.tiles_cache = old_cache
 
+    def test_wms_fetcher_caches_downloaded_image(self):
+        with tempfile.TemporaryDirectory() as cache_root:
+            old_cache = twms.fetchers.config.tiles_cache
+            twms.fetchers.config.tiles_cache = cache_root + os.sep
+            layer = {
+                "prefix": "wms-cache",
+                "ext": "png",
+                "remote_url": "http://example.test/wms?",
+                "proj": "EPSG:3857",
+            }
+            try:
+                path = self.cache_path(cache_root, layer, 2, 3, 4)
+                with mock.patch("twms.fetchers.urlopen") as urlopen:
+                    urlopen.return_value.read.return_value = self.image_bytes(
+                        (1, 2, 3, 255)
+                    )
+                    image = twms.fetchers.WMS(2, 3, 4, layer)
+
+                self.assertEqual(image.getpixel((0, 0)), (1, 2, 3, 255))
+                self.assertTrue(os.path.exists(path))
+                urlopen.assert_called_once_with(mock.ANY)
+            finally:
+                twms.fetchers.config.tiles_cache = old_cache
+
     def test_configured_http_status_tile_is_recorded_as_tne(self):
         with tempfile.TemporaryDirectory() as cache_root:
             old_cache = twms.fetchers.config.tiles_cache

--- a/tests/test_legacy_smoke.py
+++ b/tests/test_legacy_smoke.py
@@ -21,6 +21,7 @@ from PIL import Image
 
 import twms
 import twms.canvas
+import twms.config_loader
 import twms.daemon
 import twms.fetchers
 import twms.filter
@@ -46,7 +47,7 @@ class LegacySmokeTest(unittest.TestCase):
             "%s" % (x // 1024),
             "x%s" % x,
             "%s" % (y // 1024),
-            "y%s.%s" % (y, layer["ext"]),
+            "y%s.%s" % (y, twms.fetchers._layer_extension(layer)),
         )
 
     def zxy_cache_path(self, cache_root, layer, z, x, y):
@@ -55,12 +56,28 @@ class LegacySmokeTest(unittest.TestCase):
             layer["prefix"],
             "%s" % z,
             "%s" % x,
-            "%s.%s" % (y, layer["ext"]),
+            "%s.%s" % (y, twms.fetchers._layer_extension(layer)),
         )
 
     def test_public_version_keeps_keyboard_suffix(self):
         self.assertEqual(twms.__version__, "0.07z")
         self.assertEqual(importlib.metadata.version("twms"), "0.7+z")
+
+    def test_layer_metadata_normalizes_ext_and_mimetype(self):
+        module = type("Config", (), {})()
+        module.default_format = "image/png"
+        module.layers = {
+            "mimetype-only": {"mimetype": "image/png"},
+            "ext-only": {"ext": "jpg"},
+            "default-format": {},
+        }
+
+        twms.config_loader.normalize_layer_metadata(module)
+
+        self.assertEqual(module.layers["mimetype-only"]["ext"], "png")
+        self.assertEqual(module.layers["ext-only"]["mimetype"], "image/jpeg")
+        self.assertEqual(module.layers["default-format"]["mimetype"], "image/png")
+        self.assertEqual(module.layers["default-format"]["ext"], "png")
 
     def test_legacy_modules_import_as_package_modules(self):
         modules = [
@@ -180,6 +197,31 @@ class LegacySmokeTest(unittest.TestCase):
                 "Bounded</a>",
                 body,
             )
+        finally:
+            twms.twms.config.layers = old_config_layers
+            twms.twms.overview.layers = old_overview_layers
+
+    def test_overview_accepts_mimetype_only_layer(self):
+        old_config_layers = twms.twms.config.layers
+        old_overview_layers = twms.twms.overview.layers
+        layers = {
+            "typed": {
+                "name": "Typed",
+                "prefix": "typed",
+                "mimetype": "image/png",
+                "proj": "EPSG:3857",
+            }
+        }
+        twms.twms.config.layers = layers
+        twms.twms.overview.layers = layers
+        try:
+            status, content_type, body = twms.twms.twms_main(
+                {"ref": "http://example.test/"}
+            )
+
+            self.assertEqual(status, 200)
+            self.assertEqual(content_type, "text/html")
+            self.assertIn("http://example.test/typed/!/!/!.png", body)
         finally:
             twms.twms.config.layers = old_config_layers
             twms.twms.overview.layers = old_overview_layers
@@ -411,6 +453,32 @@ class LegacySmokeTest(unittest.TestCase):
         finally:
             twms.twms.config.layers = old_layers
 
+    def test_tilejson_accepts_mimetype_only_layer(self):
+        old_layers = twms.twms.config.layers
+        twms.twms.config.layers = {
+            "typed": {
+                "name": "Typed",
+                "prefix": "typed",
+                "mimetype": "image/png",
+                "proj": "EPSG:3857",
+            }
+        }
+        try:
+            status, content_type, body = twms.twms.twms_main(
+                {
+                    "request": "GetTileJSON",
+                    "layers": "typed",
+                    "ref": "http://example.test/",
+                }
+            )
+
+            doc = json.loads(body)
+            self.assertEqual(status, 200)
+            self.assertEqual(content_type, "application/json")
+            self.assertEqual(doc["tiles"], ["http://example.test/typed/{z}/{x}/{y}.png"])
+        finally:
+            twms.twms.config.layers = old_layers
+
     def test_josm_imagery_xml_smoke(self):
         status, content_type, body = twms.twms.twms_main(
             {
@@ -440,6 +508,37 @@ class LegacySmokeTest(unittest.TestCase):
         )
         self.assertEqual(osm.find("josm:valid-georeference", namespaces).text, "true")
         self.assertEqual(landsat.find("josm:max-zoom", namespaces).text, "11")
+
+    def test_josm_imagery_xml_accepts_mimetype_only_layer(self):
+        old_layers = twms.twms.config.layers
+        twms.twms.config.layers = {
+            "typed": {
+                "name": "Typed",
+                "prefix": "typed",
+                "mimetype": "image/png",
+                "proj": "EPSG:3857",
+            }
+        }
+        try:
+            status, content_type, body = twms.twms.twms_main(
+                {
+                    "request": "GetJOSMImagery",
+                    "ref": "http://example.test/",
+                }
+            )
+
+            namespaces = {"josm": "http://josm.openstreetmap.de/maps-1.0"}
+            root = ET.fromstring(body)
+            entry = root.find("./josm:entry[josm:id='twms-typed']", namespaces)
+
+            self.assertEqual(status, 200)
+            self.assertEqual(content_type, "text/xml")
+            self.assertEqual(
+                entry.find("josm:url", namespaces).text,
+                "http://example.test/typed/{zoom}/{x}/{y}.png",
+            )
+        finally:
+            twms.twms.config.layers = old_layers
 
     def test_josm_imagery_xml_layer_metadata(self):
         old_layers = twms.twms.config.layers
@@ -573,6 +672,48 @@ class LegacySmokeTest(unittest.TestCase):
             self.assertEqual(content_type, "text/xml")
             self.assertEqual(bounds.find("ows:LowerCorner", namespaces).text, "1.0 2.0")
             self.assertEqual(bounds.find("ows:UpperCorner", namespaces).text, "3.0 4.0")
+        finally:
+            twms.twms.config.layers = old_layers
+
+    def test_wmts_capabilities_accepts_mimetype_only_layer(self):
+        old_layers = twms.twms.config.layers
+        twms.twms.config.layers = {
+            "typed": {
+                "name": "Typed",
+                "prefix": "typed",
+                "mimetype": "image/png",
+                "proj": "EPSG:3857",
+            }
+        }
+        try:
+            status, content_type, body = twms.twms.twms_main(
+                {
+                    "service": "WMTS",
+                    "request": "GetCapabilities",
+                    "ref": "http://example.test/",
+                }
+            )
+
+            root = ET.fromstring(body)
+            namespaces = {
+                "wmts": "http://www.opengis.net/wmts/1.0",
+                "ows": "http://www.opengis.net/ows/1.1",
+            }
+            layer = root.find(
+                "./wmts:Contents/wmts:Layer[ows:Identifier='typed']",
+                namespaces,
+            )
+            resource = layer.find("wmts:ResourceURL", namespaces)
+            format_node = layer.find("wmts:Format", namespaces)
+
+            self.assertEqual(status, 200)
+            self.assertEqual(content_type, "text/xml")
+            self.assertEqual(resource.attrib["format"], "image/png")
+            self.assertEqual(
+                resource.attrib["template"],
+                "http://example.test/wmts/typed/{TileMatrix}/{TileCol}/{TileRow}.png",
+            )
+            self.assertEqual(format_node.text, "image/png")
         finally:
             twms.twms.config.layers = old_layers
 
@@ -1129,6 +1270,30 @@ class LegacySmokeTest(unittest.TestCase):
                     image = twms.fetchers.Tile(2, 3, 4, layer)
 
                 self.assertEqual(image.format, "JPEG")
+                with Image.open(path) as cached_image:
+                    self.assertEqual(cached_image.format, "PNG")
+            finally:
+                twms.fetchers.config.tiles_cache = old_cache
+
+    def test_tile_cache_accepts_mimetype_only_layer(self):
+        with tempfile.TemporaryDirectory() as cache_root:
+            old_cache = twms.fetchers.config.tiles_cache
+            twms.fetchers.config.tiles_cache = cache_root + os.sep
+            layer = {
+                "prefix": "mimetype",
+                "mimetype": "image/png",
+                "remote_url": "http://example.test/%s/%s/%s.jpg",
+            }
+            try:
+                path = self.cache_path(cache_root, layer, 2, 3, 4)
+                with mock.patch("twms.fetchers.urlopen") as urlopen:
+                    urlopen.return_value.read.return_value = self.image_bytes(
+                        (20, 30, 40), image_format="JPEG"
+                    )
+                    image = twms.fetchers.Tile(2, 3, 4, layer)
+
+                self.assertEqual(image.format, "JPEG")
+                self.assertTrue(path.endswith(".png"))
                 with Image.open(path) as cached_image:
                     self.assertEqual(cached_image.format, "PNG")
             finally:

--- a/tests/test_legacy_smoke.py
+++ b/tests/test_legacy_smoke.py
@@ -79,6 +79,31 @@ class LegacySmokeTest(unittest.TestCase):
         self.assertEqual(module.layers["default-format"]["mimetype"], "image/png")
         self.assertEqual(module.layers["default-format"]["ext"], "png")
 
+    def test_layer_metadata_supports_layer_defaults(self):
+        module = type("Config", (), {})()
+        module.layer_defaults = {
+            "mimetype": "image/png",
+            "proj": "EPSG:3857",
+            "cached": False,
+        }
+        module.layers = {
+            "defaulted": {"name": "Defaulted", "prefix": "defaulted"},
+            "override": {"name": "Override", "prefix": "override", "ext": "jpg"},
+        }
+
+        twms.config_loader.normalize_layer_metadata(module)
+
+        defaulted = module.layers["defaulted"]
+        override = module.layers["override"]
+        self.assertNotIn("ext", defaulted)
+        self.assertEqual(defaulted["proj"], "EPSG:3857")
+        self.assertEqual(defaulted.get("mimetype"), "image/png")
+        self.assertEqual(defaulted.get("ext"), "png")
+        self.assertEqual(defaulted.get("cached"), False)
+        self.assertEqual(override["proj"], "EPSG:3857")
+        self.assertEqual(override.get("mimetype"), "image/jpeg")
+        self.assertEqual(override.get("ext"), "jpg")
+
     def test_legacy_modules_import_as_package_modules(self):
         modules = [
             "twms.bbox",
@@ -242,6 +267,27 @@ class LegacySmokeTest(unittest.TestCase):
             self.assertEqual(status, 200)
             self.assertEqual(content_type, "text/html")
             self.assertIn("http://example.test/typed/!/!/!.png", body)
+        finally:
+            twms.twms.config.layers = old_config_layers
+            twms.twms.overview.layers = old_overview_layers
+
+    def test_overview_accepts_layer_defaults(self):
+        old_config_layers = twms.twms.config.layers
+        old_overview_layers = twms.twms.overview.layers
+        module = type("Config", (), {})()
+        module.layer_defaults = {"mimetype": "image/png", "proj": "EPSG:3857"}
+        module.layers = {"defaulted": {"name": "Defaulted", "prefix": "defaulted"}}
+        twms.config_loader.normalize_layer_metadata(module)
+        twms.twms.config.layers = module.layers
+        twms.twms.overview.layers = module.layers
+        try:
+            status, content_type, body = twms.twms.twms_main(
+                {"ref": "http://example.test/"}
+            )
+
+            self.assertEqual(status, 200)
+            self.assertEqual(content_type, "text/html")
+            self.assertIn("http://example.test/defaulted/!/!/!.png", body)
         finally:
             twms.twms.config.layers = old_config_layers
             twms.twms.overview.layers = old_overview_layers
@@ -496,6 +542,31 @@ class LegacySmokeTest(unittest.TestCase):
             self.assertEqual(status, 200)
             self.assertEqual(content_type, "application/json")
             self.assertEqual(doc["tiles"], ["http://example.test/typed/{z}/{x}/{y}.png"])
+        finally:
+            twms.twms.config.layers = old_layers
+
+    def test_tilejson_accepts_layer_defaults(self):
+        old_layers = twms.twms.config.layers
+        module = type("Config", (), {})()
+        module.layer_defaults = {"mimetype": "image/png", "proj": "EPSG:3857"}
+        module.layers = {"defaulted": {"name": "Defaulted", "prefix": "defaulted"}}
+        twms.config_loader.normalize_layer_metadata(module)
+        twms.twms.config.layers = module.layers
+        try:
+            status, content_type, body = twms.twms.twms_main(
+                {
+                    "request": "GetTileJSON",
+                    "layers": "defaulted",
+                    "ref": "http://example.test/",
+                }
+            )
+
+            doc = json.loads(body)
+            self.assertEqual(status, 200)
+            self.assertEqual(content_type, "application/json")
+            self.assertEqual(
+                doc["tiles"], ["http://example.test/defaulted/{z}/{x}/{y}.png"]
+            )
         finally:
             twms.twms.config.layers = old_layers
 

--- a/tests/test_legacy_smoke.py
+++ b/tests/test_legacy_smoke.py
@@ -48,6 +48,15 @@ class LegacySmokeTest(unittest.TestCase):
             "y%s.%s" % (y, layer["ext"]),
         )
 
+    def zxy_cache_path(self, cache_root, layer, z, x, y):
+        return os.path.join(
+            cache_root,
+            layer["prefix"],
+            "%s" % z,
+            "%s" % x,
+            "%s.%s" % (y, layer["ext"]),
+        )
+
     def test_public_version_keeps_keyboard_suffix(self):
         self.assertEqual(twms.__version__, "0.07z")
         self.assertEqual(importlib.metadata.version("twms"), "0.7+z")
@@ -389,6 +398,56 @@ class LegacySmokeTest(unittest.TestCase):
 
                 urlopen.assert_not_called()
                 self.assertEqual(image.getpixel((0, 0)), (10, 20, 30, 255))
+            finally:
+                twms.fetchers.config.tiles_cache = old_cache
+
+    def test_tile_cache_can_use_zxy_layout(self):
+        with tempfile.TemporaryDirectory() as cache_root:
+            old_cache = twms.fetchers.config.tiles_cache
+            twms.fetchers.config.tiles_cache = cache_root + os.sep
+            layer = {
+                "prefix": "zxy",
+                "ext": "png",
+                "remote_url": "http://example.test/%s/%s/%s.png",
+                "cache_layout": "zxy",
+            }
+            try:
+                path = self.zxy_cache_path(cache_root, layer, 2, 3, 4)
+                legacy_path = self.cache_path(cache_root, layer, 2, 3, 4)
+                with mock.patch("twms.fetchers.urlopen") as urlopen:
+                    urlopen.return_value.read.return_value = self.image_bytes(
+                        (10, 20, 30, 255)
+                    )
+                    image = twms.fetchers.Tile(2, 3, 4, layer)
+
+                self.assertEqual(image.getpixel((0, 0)), (10, 20, 30, 255))
+                self.assertTrue(os.path.exists(path))
+                self.assertFalse(os.path.exists(legacy_path))
+            finally:
+                twms.fetchers.config.tiles_cache = old_cache
+
+    def test_tile_cache_can_reuse_fresh_zxy_file_without_network(self):
+        with tempfile.TemporaryDirectory() as cache_root:
+            old_cache = twms.fetchers.config.tiles_cache
+            twms.fetchers.config.tiles_cache = cache_root + os.sep
+            layer = {
+                "prefix": "zxy-hit",
+                "ext": "png",
+                "remote_url": "http://example.test/%s/%s/%s.png",
+                "cache_layout": "zxy",
+                "cache_ttl": 3600,
+            }
+            try:
+                path = self.zxy_cache_path(cache_root, layer, 2, 3, 4)
+                os.makedirs(os.path.dirname(path))
+                with open(path, "wb") as tile_file:
+                    tile_file.write(self.image_bytes((70, 80, 90, 255)))
+
+                with mock.patch("twms.fetchers.urlopen") as urlopen:
+                    image = twms.fetchers.Tile(2, 3, 4, layer)
+
+                self.assertEqual(image.getpixel((0, 0)), (70, 80, 90, 255))
+                urlopen.assert_not_called()
             finally:
                 twms.fetchers.config.tiles_cache = old_cache
 

--- a/tests/test_legacy_smoke.py
+++ b/tests/test_legacy_smoke.py
@@ -61,6 +61,7 @@ class LegacySmokeTest(unittest.TestCase):
             "twms.filter",
             "twms.gpxparse",
             "twms.image_compat",
+            "twms.josm",
             "twms.overview",
             "twms.projections",
             "twms.reproject",
@@ -252,6 +253,30 @@ class LegacySmokeTest(unittest.TestCase):
         self.assertEqual(doc["bounds"], [-180.0, -85.0511287798, 180.0, 85.0511287798])
         self.assertEqual(doc["minzoom"], 0)
         self.assertEqual(doc["maxzoom"], 18)
+
+    def test_josm_imagery_xml_smoke(self):
+        status, content_type, body = twms.twms.twms_main(
+            {
+                "request": "GetJOSMImagery",
+                "ref": "http://example.test/",
+            }
+        )
+
+        namespaces = {"josm": "http://josm.openstreetmap.de/maps-1.0"}
+        root = ET.fromstring(body)
+        osm = root.find("./josm:entry[josm:id='twms-osm']", namespaces)
+        landsat = root.find("./josm:entry[josm:id='twms-landsat']", namespaces)
+
+        self.assertEqual(status, 200)
+        self.assertEqual(content_type, "text/xml")
+        self.assertEqual(root.tag, "{http://josm.openstreetmap.de/maps-1.0}imagery")
+        self.assertEqual(osm.find("josm:name", namespaces).text, "OpenStreetMap mapnik")
+        self.assertEqual(osm.find("josm:type", namespaces).text, "tms")
+        self.assertEqual(
+            osm.find("josm:url", namespaces).text,
+            "http://example.test/osm/{zoom}/{x}/{y}.png",
+        )
+        self.assertEqual(landsat.find("josm:max-zoom", namespaces).text, "11")
 
     def test_wmts_capabilities_smoke(self):
         status, content_type, body = twms.twms.twms_main(
@@ -648,6 +673,17 @@ class LegacySmokeTest(unittest.TestCase):
                 self.assertEqual(response.status, 200)
                 self.assertIn("application/json", response.headers["Content-Type"])
                 self.assertEqual(doc["tiles"], [base + "/osm/{z}/{x}/{y}.png"])
+
+            with urllib.request.urlopen(base + "/josm/imagery.xml") as response:
+                root = ET.fromstring(response.read().decode("utf-8"))
+                namespaces = {"josm": "http://josm.openstreetmap.de/maps-1.0"}
+                osm = root.find("./josm:entry[josm:id='twms-osm']", namespaces)
+                self.assertEqual(response.status, 200)
+                self.assertIn("text/xml", response.headers["Content-Type"])
+                self.assertEqual(
+                    osm.find("josm:url", namespaces).text,
+                    base + "/osm/{zoom}/{x}/{y}.png",
+                )
 
             with urllib.request.urlopen(
                 base + "/wmts/1.0.0/WMTSCapabilities.xml"

--- a/tests/test_legacy_smoke.py
+++ b/tests/test_legacy_smoke.py
@@ -1,6 +1,9 @@
 import importlib
 import importlib.metadata
+from io import BytesIO
 import unittest
+
+from PIL import Image
 
 import twms
 import twms.daemon
@@ -50,6 +53,24 @@ class LegacySmokeTest(unittest.TestCase):
         self.assertEqual(content_type, "text/html")
         self.assertIn("<table>", body)
         self.assertIn("Yandex Satellite", body)
+
+    def test_gettile_transparent_layer_smoke(self):
+        status, content_type, body = twms.twms.twms_main(
+            {
+                "request": "GetTile",
+                "layers": "transparent",
+                "format": "image/png",
+                "z": "0",
+                "x": "0",
+                "y": "0",
+            }
+        )
+
+        self.assertEqual(status, 200)
+        self.assertEqual(content_type, "image/png")
+        with Image.open(BytesIO(body)) as image:
+            self.assertEqual(image.size, (256, 256))
+            self.assertEqual(image.mode, "RGBA")
 
     def test_wsgi_application_imports(self):
         self.assertTrue(callable(twms.daemon.application))

--- a/tests/test_legacy_smoke.py
+++ b/tests/test_legacy_smoke.py
@@ -632,6 +632,58 @@ class LegacySmokeTest(unittest.TestCase):
             finally:
                 twms.fetchers.config.tiles_cache = old_cache
 
+    def test_wms_fetcher_keeps_legacy_url_append(self):
+        with tempfile.TemporaryDirectory() as cache_root:
+            old_cache = twms.fetchers.config.tiles_cache
+            twms.fetchers.config.tiles_cache = cache_root + os.sep
+            layer = {
+                "prefix": "wms-legacy-url",
+                "ext": "png",
+                "remote_url": "http://example.test/wms?",
+                "proj": "EPSG:3857",
+            }
+            try:
+                with mock.patch("twms.fetchers.urlopen") as urlopen:
+                    urlopen.return_value.read.return_value = self.image_bytes(
+                        (1, 2, 3, 255)
+                    )
+                    twms.fetchers.WMS(2, 3, 4, layer)
+
+                url = urlopen.call_args.args[0]
+                self.assertIsInstance(url, str)
+                self.assertTrue(url.startswith("http://example.test/wms?bbox="))
+                self.assertIn("&width=384&height=384&srs=EPSG:3857", url)
+            finally:
+                twms.fetchers.config.tiles_cache = old_cache
+
+    def test_wms_fetcher_formats_named_url_placeholders(self):
+        with tempfile.TemporaryDirectory() as cache_root:
+            old_cache = twms.fetchers.config.tiles_cache
+            twms.fetchers.config.tiles_cache = cache_root + os.sep
+            layer = {
+                "prefix": "wms-template-url",
+                "ext": "png",
+                "remote_url": (
+                    "http://example.test/wms?SERVICE=WMS&REQUEST=GetMap"
+                    "&WIDTH={width}&HEIGHT={height}&CRS={proj}&BBOX={bbox}"
+                ),
+                "proj": "EPSG:3857",
+            }
+            try:
+                with mock.patch("twms.fetchers.urlopen") as urlopen:
+                    urlopen.return_value.read.return_value = self.image_bytes(
+                        (1, 2, 3, 255)
+                    )
+                    twms.fetchers.WMS(2, 3, 4, layer)
+
+                url = urlopen.call_args.args[0]
+                self.assertIsInstance(url, str)
+                self.assertIn("WIDTH=384&HEIGHT=384&CRS=EPSG:3857&BBOX=", url)
+                self.assertNotIn("srs=EPSG:3857", url)
+                self.assertEqual(url.count("BBOX="), 1)
+            finally:
+                twms.fetchers.config.tiles_cache = old_cache
+
     def test_tile_fetcher_respects_min_zoom(self):
         layer = {
             "prefix": "minzoom",

--- a/tests/test_legacy_smoke.py
+++ b/tests/test_legacy_smoke.py
@@ -268,6 +268,68 @@ class LegacySmokeTest(unittest.TestCase):
         self.assertEqual(image.size, (32, 32))
         self.assertEqual(image.getpixel((0, 0)), (1, 2, 3, 255))
 
+    def test_legacy_empty_color_overlay_is_transparent(self):
+        base = Image.new("RGBA", (2, 1), (10, 20, 30, 255))
+        overlay = Image.new("RGBA", (2, 1), (255, 255, 255, 255))
+        overlay.putpixel((1, 0), (255, 0, 0, 255))
+        base.is_ok = True
+        overlay.is_ok = True
+        layers = {
+            "base": {"empty_color": "#000000"},
+            "overlay": {"empty_color": "#ffffff"},
+        }
+
+        with mock.patch.object(twms.twms.config, "layers", layers):
+            with mock.patch.object(twms.twms, "getimg", side_effect=[base, overlay]):
+                status, content_type, body = twms.twms.twms_main(
+                    {
+                        "request": "GetMap",
+                        "layers": "base,overlay",
+                        "format": "image/png",
+                        "bbox": "0,0,1,1",
+                        "width": "2",
+                        "height": "1",
+                    }
+                )
+
+        self.assertEqual(status, 200)
+        self.assertEqual(content_type, "image/png")
+        with Image.open(BytesIO(body)) as image:
+            image = image.convert("RGBA")
+            self.assertEqual(image.getpixel((0, 0)), (10, 20, 30, 255))
+            self.assertEqual(image.getpixel((1, 0)), (132, 10, 15, 255))
+
+    def test_legacy_empty_color_delta_applies_per_channel(self):
+        base = Image.new("RGBA", (1, 1), (10, 20, 30, 255))
+        overlay = Image.new("RGBA", (1, 1), (255, 254, 253, 255))
+        base.is_ok = True
+        overlay.is_ok = True
+        layers = {
+            "base": {"empty_color": "#000000"},
+            "overlay": {
+                "empty_color": "#ffffff",
+                "empty_color_delta": 2,
+            },
+        }
+
+        with mock.patch.object(twms.twms.config, "layers", layers):
+            with mock.patch.object(twms.twms, "getimg", side_effect=[base, overlay]):
+                status, content_type, body = twms.twms.twms_main(
+                    {
+                        "request": "GetMap",
+                        "layers": "base,overlay",
+                        "format": "image/png",
+                        "bbox": "0,0,1,1",
+                        "width": "1",
+                        "height": "1",
+                    }
+                )
+
+        self.assertEqual(status, 200)
+        self.assertEqual(content_type, "image/png")
+        with Image.open(BytesIO(body)) as image:
+            self.assertEqual(image.convert("RGBA").getpixel((0, 0)), (10, 20, 30, 255))
+
     def test_tilejson_smoke(self):
         status, content_type, body = twms.twms.twms_main(
             {

--- a/tests/test_legacy_smoke.py
+++ b/tests/test_legacy_smoke.py
@@ -573,6 +573,49 @@ class LegacySmokeTest(unittest.TestCase):
             finally:
                 twms.fetchers.config.tiles_cache = old_cache
 
+    def test_tile_fetcher_respects_min_zoom(self):
+        layer = {
+            "prefix": "minzoom",
+            "ext": "png",
+            "remote_url": "http://example.test/%s/%s/%s.png",
+            "min_zoom": 3,
+        }
+
+        with mock.patch("twms.fetchers.urlopen") as urlopen:
+            image = twms.fetchers.Tile(2, 3, 4, layer)
+
+        self.assertIsNone(image)
+        urlopen.assert_not_called()
+
+    def test_wms_fetcher_respects_min_zoom(self):
+        layer = {
+            "prefix": "wms-minzoom",
+            "ext": "png",
+            "remote_url": "http://example.test/wms?",
+            "proj": "EPSG:3857",
+            "min_zoom": 3,
+        }
+
+        with mock.patch("twms.fetchers.urlopen") as urlopen:
+            image = twms.fetchers.WMS(2, 3, 4, layer)
+
+        self.assertIsNone(image)
+        urlopen.assert_not_called()
+
+    def test_tile_fetcher_keeps_legacy_exclusive_max_zoom(self):
+        layer = {
+            "prefix": "maxzoom",
+            "ext": "png",
+            "remote_url": "http://example.test/%s/%s/%s.png",
+            "max_zoom": 2,
+        }
+
+        with mock.patch("twms.fetchers.urlopen") as urlopen:
+            image = twms.fetchers.Tile(2, 3, 4, layer)
+
+        self.assertIsNone(image)
+        urlopen.assert_not_called()
+
     def test_tile_fetcher_sends_configured_headers(self):
         with tempfile.TemporaryDirectory() as cache_root:
             old_cache = twms.fetchers.config.tiles_cache

--- a/twms/__init__.py
+++ b/twms/__init__.py
@@ -1,6 +1,25 @@
 # -*- coding: utf-8 -*-
 
+import os
+import sys
+
+package_dir = os.path.dirname(__file__)
+if package_dir not in sys.path:
+    sys.path.append(package_dir)
+
+from .config_loader import load_default_config
 from .version import __version__
+
+
+load_default_config()
+
+
+def __getattr__(name):
+    if name in {"getimg", "tile_image", "twms_main"}:
+        from . import twms as twms_module
+
+        return getattr(twms_module, name)
+    raise AttributeError(name)
 
 
 __all__ = [

--- a/twms/__init__.py
+++ b/twms/__init__.py
@@ -29,6 +29,7 @@ __all__ = [
     "canvas",
     "correctify",
     "drawing",
+    "image_compat",
     "projections",
     "reproject",
     "wmts",

--- a/twms/__init__.py
+++ b/twms/__init__.py
@@ -31,4 +31,5 @@ __all__ = [
     "drawing",
     "projections",
     "reproject",
+    "wmts",
 ]

--- a/twms/__init__.py
+++ b/twms/__init__.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 
+from .version import __version__
+
+
 __all__ = [
+    "__version__",
     "twms",
     "bbox",
     "canvas",

--- a/twms/__init__.py
+++ b/twms/__init__.py
@@ -30,6 +30,7 @@ __all__ = [
     "correctify",
     "drawing",
     "image_compat",
+    "josm",
     "projections",
     "reproject",
     "wmts",

--- a/twms/__main__.py
+++ b/twms/__main__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+
+from .server import main
+
+
+if __name__ == "__main__":
+    main()

--- a/twms/canvas.py
+++ b/twms/canvas.py
@@ -15,7 +15,7 @@
 import datetime
 import sys
 import threading
-import urllib
+from urllib.request import urlopen
 from io import BytesIO
 
 import projections
@@ -105,7 +105,7 @@ class WmsCanvas:
                 remote = self.ConstructTileUrl(x, y)
                 debug(remote)
                 ttz = datetime.datetime.now()
-                contents = urllib.urlopen(remote).read()
+                contents = urlopen(remote).read()
                 debug("Download took %s" % str(datetime.datetime.now() - ttz))
                 im = Image.open(BytesIO(contents))
                 if im.mode != self.mode:
@@ -133,7 +133,7 @@ class WmsCanvas:
                     group=None,
                     target=self.FetchTile,
                     name=None,
-                    args=(self, tile_x, tile_y),
+                    args=(tile_x, tile_y),
                     kwargs={},
                 )
                 self.tiles[(tile_x, tile_y)]["thread"].start()

--- a/twms/canvas.py
+++ b/twms/canvas.py
@@ -18,6 +18,7 @@ import threading
 from urllib.request import urlopen
 from io import BytesIO
 
+import config
 import projections
 from PIL import Image, ImageFilter
 
@@ -35,12 +36,14 @@ class WmsCanvas:
         tile_size=None,
         mode="RGBA",
         tile_mode="WMS",
+        timeout="default",
     ):
         self.wms_url = wms_url
         self.zoom = zoom
         self.proj = proj
         self.mode = mode
         self.tile_mode = tile_mode
+        self.timeout = timeout
         self.tile_height = 256
         self.tile_width = 256
 
@@ -105,7 +108,7 @@ class WmsCanvas:
                 remote = self.ConstructTileUrl(x, y)
                 debug(remote)
                 ttz = datetime.datetime.now()
-                contents = urlopen(remote).read()
+                contents = urlopen(remote, timeout=self.UpstreamTimeout()).read()
                 debug("Download took %s" % str(datetime.datetime.now() - ttz))
                 im = Image.open(BytesIO(contents))
                 if im.mode != self.mode:
@@ -117,6 +120,15 @@ class WmsCanvas:
             self.tiles[(x, y)]["im"] = im
             self.tiles[(x, y)]["pix"] = im.load()
             self.tiles[(x, y)]["status"] = "RD"
+
+    def UpstreamTimeout(self):
+        if self.timeout != "default":
+            return self.timeout
+        return getattr(
+            config,
+            "upstream_timeout",
+            min(getattr(config, "deadline", 30), 30),
+        )
 
     def PreparePixel(self, x, y):
         tile_x = int(x / self.tile_height)

--- a/twms/capabilities.py
+++ b/twms/capabilities.py
@@ -5,12 +5,134 @@
 # the extent permitted by applicable law. You can redistribute it
 # and/or modify it under the terms specified in COPYING.
 
+import xml.etree.ElementTree as ET
+
 import config
 import projections
 
 
+WMS = "http://www.opengis.net/wms"
+XLINK = "http://www.w3.org/1999/xlink"
+
+
+def _wms130_bbox(layer):
+    bbox = layer.get("bbox", config.default_bbox)
+    proj = layer.get("proj", "EPSG:3857")
+    if projections.proj_alias.get(proj, proj) == "EPSG:4326":
+        return "CRS:84", bbox
+    return proj, projections.from4326(bbox, proj)
+
+
+def _legacy_srs_ids():
+    return sorted(
+        proj
+        for proj in projections.projs.keys() | projections.proj_alias.keys()
+        if not proj.startswith("CRS:")
+    )
+
+
+def _wms130(ref):
+    content_type = "text/xml"
+
+    ET.register_namespace("", WMS)
+    ET.register_namespace("xlink", XLINK)
+
+    root = ET.Element(
+        "{%s}WMS_Capabilities" % WMS,
+        attrib={"version": "1.3.0"},
+    )
+    service = ET.SubElement(root, "Service")
+    ET.SubElement(service, "Name").text = "WMS"
+    ET.SubElement(service, "Title").text = config.wms_name
+    ET.SubElement(
+        service,
+        "OnlineResource",
+        attrib={
+            "{%s}type" % XLINK: "simple",
+            "{%s}href" % XLINK: ref,
+        },
+    )
+    ET.SubElement(service, "Fees").text = "none"
+    ET.SubElement(service, "AccessConstraints").text = "none"
+
+    capability = ET.SubElement(root, "Capability")
+    request = ET.SubElement(capability, "Request")
+    get_capabilities = ET.SubElement(request, "GetCapabilities")
+    ET.SubElement(get_capabilities, "Format").text = "text/xml"
+    ET.SubElement(
+        ET.SubElement(
+            ET.SubElement(ET.SubElement(get_capabilities, "DCPType"), "HTTP"),
+            "Get",
+        ),
+        "OnlineResource",
+        attrib={
+            "{%s}type" % XLINK: "simple",
+            "{%s}href" % XLINK: ref,
+        },
+    )
+
+    get_map = ET.SubElement(request, "GetMap")
+    for image_format in ("image/png", "image/jpeg", "image/gif", "image/bmp"):
+        ET.SubElement(get_map, "Format").text = image_format
+    ET.SubElement(
+        ET.SubElement(ET.SubElement(ET.SubElement(get_map, "DCPType"), "HTTP"), "Get"),
+        "OnlineResource",
+        attrib={
+            "{%s}type" % XLINK: "simple",
+            "{%s}href" % XLINK: ref,
+        },
+    )
+
+    exceptions = ET.SubElement(capability, "Exception")
+    ET.SubElement(exceptions, "Format").text = "XML"
+
+    parent = ET.SubElement(capability, "Layer")
+    ET.SubElement(parent, "Title").text = config.wms_name
+    ET.SubElement(parent, "CRS").text = "CRS:84"
+    west, south, east, north = config.default_bbox
+    geo_bbox = ET.SubElement(parent, "EX_GeographicBoundingBox")
+    ET.SubElement(geo_bbox, "westBoundLongitude").text = str(west)
+    ET.SubElement(geo_bbox, "eastBoundLongitude").text = str(east)
+    ET.SubElement(geo_bbox, "southBoundLatitude").text = str(south)
+    ET.SubElement(geo_bbox, "northBoundLatitude").text = str(north)
+
+    for layer_id in config.layers.keys():
+        layer_config = config.layers[layer_id]
+        layer = ET.SubElement(parent, "Layer", attrib={"queryable": "0", "opaque": "1"})
+        ET.SubElement(layer, "Name").text = layer_id
+        ET.SubElement(layer, "Title").text = layer_config["name"]
+        ET.SubElement(layer, "CRS").text = "CRS:84"
+        bbox = layer_config.get("bbox", config.default_bbox)
+        west, south, east, north = bbox
+        geo_bbox = ET.SubElement(layer, "EX_GeographicBoundingBox")
+        ET.SubElement(geo_bbox, "westBoundLongitude").text = str(west)
+        ET.SubElement(geo_bbox, "eastBoundLongitude").text = str(east)
+        ET.SubElement(geo_bbox, "southBoundLatitude").text = str(south)
+        ET.SubElement(geo_bbox, "northBoundLatitude").text = str(north)
+
+        bbox_crs, native_bbox = _wms130_bbox(layer_config)
+        ET.SubElement(layer, "CRS").text = bbox_crs
+        ET.SubElement(
+            layer,
+            "BoundingBox",
+            attrib={
+                "CRS": bbox_crs,
+                "minx": str(native_bbox[0]),
+                "miny": str(native_bbox[1]),
+                "maxx": str(native_bbox[2]),
+                "maxy": str(native_bbox[3]),
+            },
+        )
+
+    ET.indent(root)
+    return content_type, ET.tostring(root, encoding="unicode", xml_declaration=True)
+
+
 def get(version, ref):
     content_type = "text/xml"
+
+    if version == "1.3.0":
+        return _wms130(ref)
 
     if version == "1.0.0":
         req = (
@@ -103,9 +225,7 @@ def get(version, ref):
             + """</Title>
                         <Abstract/>"""
         )
-        pset = set(projections.projs.keys())
-        pset = pset.union(set(projections.proj_alias.keys()))
-        for proj in pset:
+        for proj in _legacy_srs_ids():
             req += "<SRS>%s</SRS>" % proj
         req += """<LatLonBoundingBox minx="-180" miny="-85.0511287798" maxx="180" maxy="85.0511287798"/>
                         <BoundingBox SRS="EPSG:4326" minx="-184" miny="85.0511287798" maxx="180" maxy="85.0511287798"/>
@@ -216,9 +336,7 @@ def get(version, ref):
                 <Layer>
                         <Title>World Map</Title>"""
         )
-        pset = set(projections.projs.keys())
-        pset = pset.union(set(projections.proj_alias.keys()))
-        for proj in pset:
+        for proj in _legacy_srs_ids():
             req += "<SRS>%s</SRS>" % proj
         req += """
                         <LatLonBoundingBox minx="-180" miny="-85.0511287798" maxx="180" maxy="85.0511287798"/>

--- a/twms/capabilities.py
+++ b/twms/capabilities.py
@@ -72,7 +72,13 @@ def _wms130(ref):
     )
 
     get_map = ET.SubElement(request, "GetMap")
-    for image_format in ("image/png", "image/jpeg", "image/gif", "image/bmp"):
+    for image_format in (
+        "image/png",
+        "image/jpeg",
+        "image/gif",
+        "image/bmp",
+        "image/webp",
+    ):
         ET.SubElement(get_map, "Format").text = image_format
     ET.SubElement(
         ET.SubElement(ET.SubElement(ET.SubElement(get_map, "DCPType"), "HTTP"), "Get"),
@@ -312,6 +318,7 @@ def get(version, ref):
                                 <Format>image/jpeg</Format>
                                 <Format>image/gif</Format>
                                 <Format>image/bmp</Format>
+                                <Format>image/webp</Format>
                                 <DCPType>
                                         <HTTP>
                                                 <Get>

--- a/twms/config_loader.py
+++ b/twms/config_loader.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+
+import importlib.machinery
+import importlib.util
+import os
+import sys
+
+
+def load_config(path):
+    loader = importlib.machinery.SourceFileLoader("twms.config", path)
+    spec = importlib.util.spec_from_loader("twms.config", loader)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["twms.config"] = module
+    sys.modules["config"] = module
+    loader.exec_module(module)
+    return module
+
+
+def load_default_config():
+    if "config" in sys.modules:
+        return sys.modules["config"]
+
+    package_dir = os.path.dirname(__file__)
+    paths = [
+        "/etc/twms/twms.conf",
+        os.path.join(package_dir, "twms.conf"),
+        os.path.join(os.path.realpath(sys.path[0]), "twms.conf"),
+    ]
+    for path in paths:
+        if os.path.exists(path):
+            return load_config(path)
+    return load_config(paths[-1])

--- a/twms/config_loader.py
+++ b/twms/config_loader.py
@@ -7,6 +7,22 @@ import os
 import sys
 
 
+class LayerConfig(dict):
+    def __init__(self, defaults, values):
+        super().__init__(values)
+        self.defaults = defaults
+
+    def __missing__(self, key):
+        if key in self.defaults:
+            return self.defaults[key]
+        raise KeyError(key)
+
+    def get(self, key, default=None):
+        if key in self:
+            return super().get(key)
+        return self.defaults.get(key, default)
+
+
 def _extension_from_mimetype(mimetype):
     extension = mimetypes.guess_extension(mimetype or "")
     if not extension:
@@ -23,22 +39,31 @@ def _mimetype_from_extension(extension):
     return None
 
 
+def _normalize_format_metadata(layer, default_mimetype=None):
+    if "mimetype" in layer and "ext" not in layer:
+        extension = _extension_from_mimetype(layer["mimetype"])
+        if extension:
+            layer["ext"] = extension
+    if "ext" in layer and "mimetype" not in layer:
+        mimetype = _mimetype_from_extension(layer["ext"])
+        if mimetype:
+            layer["mimetype"] = mimetype
+    if "ext" not in layer and "mimetype" not in layer and default_mimetype:
+        layer["mimetype"] = default_mimetype
+        extension = _extension_from_mimetype(default_mimetype)
+        if extension:
+            layer["ext"] = extension
+
+
 def normalize_layer_metadata(module):
     default_mimetype = getattr(module, "default_format", None)
-    for layer in getattr(module, "layers", {}).values():
-        if "mimetype" in layer and "ext" not in layer:
-            extension = _extension_from_mimetype(layer["mimetype"])
-            if extension:
-                layer["ext"] = extension
-        if "ext" in layer and "mimetype" not in layer:
-            mimetype = _mimetype_from_extension(layer["ext"])
-            if mimetype:
-                layer["mimetype"] = mimetype
-        if "ext" not in layer and "mimetype" not in layer and default_mimetype:
-            layer["mimetype"] = default_mimetype
-            extension = _extension_from_mimetype(default_mimetype)
-            if extension:
-                layer["ext"] = extension
+    layer_defaults = getattr(module, "layer_defaults", None)
+    if isinstance(layer_defaults, dict):
+        _normalize_format_metadata(layer_defaults, default_mimetype)
+    for name, layer in list(getattr(module, "layers", {}).items()):
+        _normalize_format_metadata(layer, default_mimetype)
+        if isinstance(layer_defaults, dict):
+            module.layers[name] = LayerConfig(layer_defaults, layer)
 
 
 def load_config(path):

--- a/twms/config_loader.py
+++ b/twms/config_loader.py
@@ -2,8 +2,43 @@
 
 import importlib.machinery
 import importlib.util
+import mimetypes
 import os
 import sys
+
+
+def _extension_from_mimetype(mimetype):
+    extension = mimetypes.guess_extension(mimetype or "")
+    if not extension:
+        return None
+    return extension.strip(".").lower().replace("jpeg", "jpg")
+
+
+def _mimetype_from_extension(extension):
+    extension = (extension or "").lower().strip(".").replace("jpeg", "jpg")
+    if extension == "jpg":
+        return "image/jpeg"
+    if extension:
+        return mimetypes.types_map.get("." + extension, "image/" + extension)
+    return None
+
+
+def normalize_layer_metadata(module):
+    default_mimetype = getattr(module, "default_format", None)
+    for layer in getattr(module, "layers", {}).values():
+        if "mimetype" in layer and "ext" not in layer:
+            extension = _extension_from_mimetype(layer["mimetype"])
+            if extension:
+                layer["ext"] = extension
+        if "ext" in layer and "mimetype" not in layer:
+            mimetype = _mimetype_from_extension(layer["ext"])
+            if mimetype:
+                layer["mimetype"] = mimetype
+        if "ext" not in layer and "mimetype" not in layer and default_mimetype:
+            layer["mimetype"] = default_mimetype
+            extension = _extension_from_mimetype(default_mimetype)
+            if extension:
+                layer["ext"] = extension
 
 
 def load_config(path):
@@ -13,6 +48,7 @@ def load_config(path):
     sys.modules["twms.config"] = module
     sys.modules["config"] = module
     loader.exec_module(module)
+    normalize_layer_metadata(module)
     return module
 
 

--- a/twms/config_loader.py
+++ b/twms/config_loader.py
@@ -55,13 +55,33 @@ def _normalize_format_metadata(layer, default_mimetype=None):
             layer["ext"] = extension
 
 
+def _normalize_fetch_metadata(layer):
+    fetch = layer.get("fetch")
+    if not isinstance(fetch, str):
+        return
+
+    from twms import fetchers
+
+    fetchers_by_name = {
+        "tile": fetchers.Tile,
+        "tms": fetchers.Tile,
+        "wms": fetchers.WMS,
+    }
+    try:
+        layer["fetch"] = fetchers_by_name[fetch.lower()]
+    except KeyError:
+        raise ValueError("Unknown fetcher alias: %s" % fetch)
+
+
 def normalize_layer_metadata(module):
     default_mimetype = getattr(module, "default_format", None)
     layer_defaults = getattr(module, "layer_defaults", None)
     if isinstance(layer_defaults, dict):
         _normalize_format_metadata(layer_defaults, default_mimetype)
+        _normalize_fetch_metadata(layer_defaults)
     for name, layer in list(getattr(module, "layers", {}).items()):
         _normalize_format_metadata(layer, default_mimetype)
+        _normalize_fetch_metadata(layer)
         if isinstance(layer_defaults, dict):
             module.layers[name] = LayerConfig(layer_defaults, layer)
 

--- a/twms/daemon.py
+++ b/twms/daemon.py
@@ -37,7 +37,7 @@ def handler(data):
 
 
 urls = (
-    "/(.*)/([0-9]+)/([0-9]+)/([0-9]+)(\.[a-zA-Z]+)?(.*)", "tilehandler",
+    r"/(.*)/([0-9]+)/([0-9]+)/([0-9]+)(\.[a-zA-Z]+)?(.*)", "tilehandler",
     "/(.*)", "mainhandler",
 )
 

--- a/twms/drawing.py
+++ b/twms/drawing.py
@@ -104,7 +104,7 @@ def render_vector(
 
     if renderer == "cairo" and HAVE_CAIRO:
         "rendering as cairo"
-        imgd = img.tostring()
+        imgd = img.tobytes()
         a = array.array("B", imgd)
         surface = cairo.ImageSurface.create_for_data(
             a, cairo.FORMAT_ARGB32, W, H, W * 4

--- a/twms/fetchers.py
+++ b/twms/fetchers.py
@@ -25,6 +25,14 @@ fetching_now = {}
 thread_responses = {}
 zhash_lock = {}
 
+_EXTENSION_FORMATS = {
+    "gif": "GIF",
+    "jpg": "JPEG",
+    "jpeg": "JPEG",
+    "png": "PNG",
+    "webp": "WEBP",
+}
+
 
 def _cache_stem(z, x, y, this_layer):
     return (
@@ -195,7 +203,10 @@ def WMS(z, x, y, this_layer):
             return cache.wait_for_peer()
     try:
         try:
-            im = Image.open(BytesIO(urlopen(wms).read()))
+            contents = urlopen(wms).read()
+            im = _open_downloaded_image(contents)
+            if im is None:
+                raise OSError
         except OSError:
             stale = cache.open_image(include_stale=True)
             if stale is not None:
@@ -243,7 +254,9 @@ def Tile(z, x, y, this_layer):
     try:
         try:
             contents = urlopen(remote).read()
-            im = Image.open(BytesIO(contents))
+            im = _open_downloaded_image(contents)
+            if im is None:
+                raise OSError
         except OSError:
             stale = cache.open_image(include_stale=True)
             if stale is not None:
@@ -253,11 +266,44 @@ def Tile(z, x, y, this_layer):
             cache.mark_tne()
             return False
         if this_layer.get("cached", True):
-            cache.write_bytes(contents)
+            cache.write_bytes(_cache_image_bytes(contents, im, this_layer["ext"]))
         return im
     finally:
         if locked:
             cache.release()
+
+
+def _open_downloaded_image(contents):
+    if not contents:
+        return None
+    image = Image.open(BytesIO(contents))
+    image.load()
+    return image
+
+
+def _cache_image_bytes(contents, image, extension):
+    target_format = _EXTENSION_FORMATS.get(extension.lower())
+    if target_format is None or image.format == target_format:
+        return contents
+
+    image_content = BytesIO()
+    if target_format == "JPEG":
+        image = image.convert("RGB")
+        image.save(
+            image_content,
+            target_format,
+            quality=config.output_quality,
+            progressive=config.output_progressive,
+        )
+    elif target_format == "PNG":
+        image.save(
+            image_content,
+            target_format,
+            optimize=config.output_optimize,
+        )
+    else:
+        image.save(image_content, target_format)
+    return image_content.getvalue()
 
 
 def _is_dead_tile(contents, dead_tile):

--- a/twms/fetchers.py
+++ b/twms/fetchers.py
@@ -14,6 +14,7 @@ import threading
 import time
 from io import BytesIO
 from urllib.error import HTTPError
+from urllib.error import URLError
 from urllib.request import Request, urlopen
 
 import config
@@ -61,11 +62,38 @@ def _upstream_timeout(this_layer):
     )
 
 
+def _upstream_retries(this_layer):
+    return max(
+        1,
+        int(this_layer.get("upstream_retries", getattr(config, "upstream_retries", 1))),
+    )
+
+
+def _upstream_retry_delay(this_layer):
+    return float(
+        this_layer.get(
+            "upstream_retry_delay", getattr(config, "upstream_retry_delay", 0)
+        )
+    )
+
+
 def _read_upstream(url, this_layer):
-    return urlopen(
-        _upstream_request(url, this_layer),
-        timeout=_upstream_timeout(this_layer),
-    ).read()
+    attempts = _upstream_retries(this_layer)
+    for attempt in range(attempts):
+        try:
+            return urlopen(
+                _upstream_request(url, this_layer),
+                timeout=_upstream_timeout(this_layer),
+            ).read()
+        except HTTPError:
+            raise
+        except (OSError, URLError):
+            if attempt + 1 == attempts:
+                raise
+            delay = _upstream_retry_delay(this_layer)
+            if delay:
+                time.sleep(delay)
+
 
 
 def _outside_zoom_limits(z, this_layer):

--- a/twms/fetchers.py
+++ b/twms/fetchers.py
@@ -13,6 +13,7 @@ import sys
 import threading
 import time
 from io import BytesIO
+from urllib.error import HTTPError
 from urllib.request import urlopen
 
 import config
@@ -257,6 +258,14 @@ def Tile(z, x, y, this_layer):
             im = _open_downloaded_image(contents)
             if im is None:
                 raise OSError
+        except HTTPError as error:
+            if _is_tne_http_error(error, this_layer):
+                cache.mark_tne()
+                return False
+            stale = cache.open_image(include_stale=True)
+            if stale is not None:
+                return stale
+            return False
         except OSError:
             stale = cache.open_image(include_stale=True)
             if stale is not None:
@@ -304,6 +313,21 @@ def _cache_image_bytes(contents, image, extension):
     else:
         image.save(image_content, target_format)
     return image_content.getvalue()
+
+
+def _is_tne_http_error(error, this_layer):
+    status = getattr(error, "status", error.code)
+    if status == 404:
+        return True
+
+    dead_tile = this_layer.get("dead_tile")
+    if not isinstance(dead_tile, dict) or "http_status" not in dead_tile:
+        return False
+
+    configured = dead_tile["http_status"]
+    if isinstance(configured, (list, tuple, set)):
+        return status in configured
+    return status == configured
 
 
 def _is_dead_tile(contents, dead_tile):

--- a/twms/fetchers.py
+++ b/twms/fetchers.py
@@ -50,6 +50,14 @@ def _upstream_request(url, this_layer):
     return url
 
 
+def _outside_zoom_limits(z, this_layer):
+    if "min_zoom" in this_layer and z < this_layer["min_zoom"]:
+        return True
+    if "max_zoom" in this_layer and z >= this_layer["max_zoom"]:
+        return True
+    return False
+
+
 class TileCache:
     """Small filesystem cache helper.
 
@@ -188,9 +196,8 @@ def threadwrapper(z, x, y, this_layer, zhash):
 
 
 def WMS(z, x, y, this_layer):
-    if "max_zoom" in this_layer:
-        if z >= this_layer["max_zoom"]:
-            return None
+    if _outside_zoom_limits(z, this_layer):
+        return None
     wms = this_layer["remote_url"]
     req_proj = this_layer.get("wms_proj", this_layer["proj"])
     width = 384  # using larger source size to rescale better in python
@@ -243,9 +250,8 @@ def WMS(z, x, y, this_layer):
 def Tile(z, x, y, this_layer):
     global OSError, IOError
     d_tuple = z, x, y
-    if "max_zoom" in this_layer:
-        if z >= this_layer["max_zoom"]:
-            return None
+    if _outside_zoom_limits(z, this_layer):
+        return None
     if "transform_tile_number" in this_layer:
         d_tuple = this_layer["transform_tile_number"](z, x, y)
 

--- a/twms/fetchers.py
+++ b/twms/fetchers.py
@@ -18,6 +18,7 @@ from urllib.request import urlopen
 import config
 import projections
 from PIL import Image
+from twms.image_compat import resampling_lanczos
 
 
 fetching_now = {}
@@ -201,7 +202,7 @@ def WMS(z, x, y, this_layer):
                 return stale
             return False
         if width != 256 and height != 256:
-            im = im.resize((256, 256), Image.ANTIALIAS)
+            im = im.resize((256, 256), resampling_lanczos(Image))
         im = im.convert("RGBA")
 
         if this_layer.get("cached", True):

--- a/twms/fetchers.py
+++ b/twms/fetchers.py
@@ -14,7 +14,7 @@ import threading
 import time
 from io import BytesIO
 from urllib.error import HTTPError
-from urllib.request import urlopen
+from urllib.request import Request, urlopen
 
 import config
 import projections
@@ -41,6 +41,13 @@ def _cache_stem(z, x, y, this_layer):
         + this_layer["prefix"]
         + "/z%s/%s/x%s/%s/y%s." % (z, x // 1024, x, y // 1024, y)
     )
+
+
+def _upstream_request(url, this_layer):
+    headers = this_layer.get("headers")
+    if headers:
+        return Request(url, headers=headers)
+    return url
 
 
 class TileCache:
@@ -204,7 +211,7 @@ def WMS(z, x, y, this_layer):
             return cache.wait_for_peer()
     try:
         try:
-            contents = urlopen(wms).read()
+            contents = urlopen(_upstream_request(wms, this_layer)).read()
             im = _open_downloaded_image(contents)
             if im is None:
                 raise OSError
@@ -254,7 +261,7 @@ def Tile(z, x, y, this_layer):
             return cache.wait_for_peer()
     try:
         try:
-            contents = urlopen(remote).read()
+            contents = urlopen(_upstream_request(remote, this_layer)).read()
             im = _open_downloaded_image(contents)
             if im is None:
                 raise OSError

--- a/twms/fetchers.py
+++ b/twms/fetchers.py
@@ -6,6 +6,7 @@
 # and/or modify it under the terms specified in COPYING.
 
 import filecmp
+import hashlib
 import math
 import os
 import sys
@@ -22,6 +23,114 @@ from PIL import Image
 fetching_now = {}
 thread_responses = {}
 zhash_lock = {}
+
+
+def _cache_stem(z, x, y, this_layer):
+    return (
+        config.tiles_cache
+        + this_layer["prefix"]
+        + "/z%s/%s/x%s/%s/y%s." % (z, x // 1024, x, y // 1024, y)
+    )
+
+
+class TileCache:
+    """Small filesystem cache helper.
+
+    This keeps TWMS' historical zN/NNN/xN/NNN/yN.ext layout, but adds the useful
+    cache semantics from Radioxoma's fork: TTL checks, readable TNE markers,
+    stale-cache fallback, and atomic file replacement.
+    """
+
+    def __init__(self, z, x, y, this_layer):
+        self.layer = this_layer
+        self.cached = this_layer.get("cached", True)
+        if self.cached:
+            self.stem = _cache_stem(z, x, y, this_layer)
+            self.path = self.stem + this_layer["ext"]
+            self.tne_path = self.stem + "tne"
+            self.lock_path = self.stem + "lock"
+        else:
+            self.stem = None
+            self.path = None
+            self.tne_path = None
+            self.lock_path = None
+
+    def _fresh(self, path):
+        if not os.path.exists(path):
+            return False
+        ttl = self.layer.get("cache_ttl")
+        if not ttl:
+            return True
+        return time.time() - os.path.getmtime(path) <= ttl
+
+    def needs_fetch(self):
+        if not self.cached:
+            return True
+        if self._fresh(self.tne_path):
+            return False
+        if self._fresh(self.path):
+            return False
+        return True
+
+    def open_image(self, include_stale=False):
+        if not self.cached or not os.path.exists(self.path):
+            return None
+        if not include_stale and not self._fresh(self.path):
+            return None
+        return Image.open(self.path)
+
+    def ensure_parent(self):
+        parent = os.path.dirname(self.stem)
+        if parent and not os.path.exists(parent):
+            os.makedirs(parent)
+
+    def acquire(self):
+        if not self.cached:
+            return False
+        self.ensure_parent()
+        os.mkdir(self.lock_path)
+        return True
+
+    def release(self):
+        if self.cached and os.path.exists(self.lock_path):
+            os.rmdir(self.lock_path)
+
+    def wait_for_peer(self):
+        for _ in range(20):
+            time.sleep(0.1)
+            if not os.path.exists(self.lock_path):
+                if self._fresh(self.tne_path):
+                    return None
+                return self.open_image()
+        return None
+
+    def write_bytes(self, contents):
+        if not self.cached:
+            return
+        tmp_path = self.path + ".tmp.%s" % os.getpid()
+        with open(tmp_path, "wb") as tile_file:
+            tile_file.write(contents)
+        os.replace(tmp_path, self.path)
+        if os.path.exists(self.tne_path):
+            os.remove(self.tne_path)
+
+    def save_image(self, image):
+        if not self.cached:
+            return
+        tmp_path = self.path + ".tmp.%s" % os.getpid()
+        image.save(tmp_path)
+        os.replace(tmp_path, self.path)
+        if os.path.exists(self.tne_path):
+            os.remove(self.tne_path)
+
+    def mark_tne(self):
+        if not self.cached:
+            return
+        self.ensure_parent()
+        if os.path.exists(self.path):
+            os.remove(self.path)
+        with open(self.tne_path, "wb") as tne:
+            tne.write(b"")
 
 
 def fetch(z, x, y, this_layer):
@@ -69,51 +178,46 @@ def WMS(z, x, y, this_layer):
     req_proj = this_layer.get("wms_proj", this_layer["proj"])
     width = 384  # using larger source size to rescale better in python
     height = 384
-    local = (
-        config.tiles_cache
-        + this_layer["prefix"]
-        + "/z%s/%s/x%s/%s/y%s." % (z, x / 1024, x, y / 1024, y)
-    )
+    cache = TileCache(z, x, y, this_layer)
     tile_bbox = "bbox=%s,%s,%s,%s" % tuple(
         projections.from4326(projections.bbox_by_tile(z, x, y, req_proj), req_proj)
     )
 
     wms += tile_bbox + "&width=%s&height=%s&srs=%s" % (width, height, req_proj)
+    if this_layer.get("cached", True) and not cache.needs_fetch():
+        return cache.open_image()
+    locked = False
     if this_layer.get("cached", True):
-        if not os.path.exists("/".join(local.split("/")[:-1])):
-            os.makedirs("/".join(local.split("/")[:-1]))
         try:
-            os.mkdir(local + "lock")
+            locked = cache.acquire()
         except OSError:
-            for i in range(20):
-                time.sleep(0.1)
-                try:
-                    if not os.path.exists(local + "lock"):
-                        im = Image.open(local + this_layer["ext"])
-                        return im
-                except (IOError, OSError):
-                    return None
-    im = Image.open(BytesIO(urlopen(wms).read()))
-    if width != 256 and height != 256:
-        im = im.resize((256, 256), Image.ANTIALIAS)
-    im = im.convert("RGBA")
-
-    if this_layer.get("cached", True):
-        ic = Image.new(
-            "RGBA", (256, 256), this_layer.get("empty_color", config.default_background)
-        )
-        if im.histogram() == ic.histogram():
-            tne = open(local + "tne", "wb")
-            when = time.localtime()
-            tne.write(
-                "%02d.%02d.%04d %02d:%02d:%02d"
-                % (when[2], when[1], when[0], when[3], when[4], when[5])
-            )
-            tne.close()
+            return cache.wait_for_peer()
+    try:
+        try:
+            im = Image.open(BytesIO(urlopen(wms).read()))
+        except OSError:
+            stale = cache.open_image(include_stale=True)
+            if stale is not None:
+                return stale
             return False
-        im.save(local + this_layer["ext"])
-        os.rmdir(local + "lock")
-    return im
+        if width != 256 and height != 256:
+            im = im.resize((256, 256), Image.ANTIALIAS)
+        im = im.convert("RGBA")
+
+        if this_layer.get("cached", True):
+            ic = Image.new(
+                "RGBA",
+                (256, 256),
+                this_layer.get("empty_color", config.default_background),
+            )
+            if im.histogram() == ic.histogram():
+                cache.mark_tne()
+                return False
+            cache.save_image(im)
+        return im
+    finally:
+        if locked:
+            cache.release()
 
 
 def Tile(z, x, y, this_layer):
@@ -126,49 +230,49 @@ def Tile(z, x, y, this_layer):
         d_tuple = this_layer["transform_tile_number"](z, x, y)
 
     remote = this_layer["remote_url"] % d_tuple
+    cache = TileCache(z, x, y, this_layer)
+    if this_layer.get("cached", True) and not cache.needs_fetch():
+        return cache.open_image()
+    locked = False
     if this_layer.get("cached", True):
-        local = (
-            config.tiles_cache
-            + this_layer["prefix"]
-            + "/z%s/%s/x%s/%s/y%s." % (z, x / 1024, x, y / 1024, y)
-        )
-        if not os.path.exists("/".join(local.split("/")[:-1])):
-            os.makedirs("/".join(local.split("/")[:-1]))
         try:
-            os.mkdir(local + "lock")
+            locked = cache.acquire()
         except OSError:
-            for i in range(20):
-                time.sleep(0.1)
-                try:
-                    if not os.path.exists(local + "lock"):
-                        im = Image.open(local + this_layer["ext"])
-                        return im
-                except (IOError, OSError):
-                    return None
+            return cache.wait_for_peer()
     try:
-        contents = urlopen(remote).read()
-        im = Image.open(BytesIO(contents))
-    except IOError:
-        if this_layer.get("cached", True):
-            os.rmdir(local + "lock")
-        return False
-    if this_layer.get("cached", True):
-        os.rmdir(local + "lock")
-        open(local + this_layer["ext"], "wb").write(contents)
-    if "dead_tile" in this_layer:
         try:
-            dt = open(this_layer["dead_tile"], "rb").read()
-            if contents == dt:
-                if this_layer.get("cached", True):
-                    tne = open(local + "tne", "wb")
-                    when = time.localtime()
-                    tne.write(
-                        "%02d.%02d.%04d %02d:%02d:%02d"
-                        % (when[2], when[1], when[0], when[3], when[4], when[5])
-                    )
-                    tne.close()
-                    os.remove(local + this_layer["ext"])
+            contents = urlopen(remote).read()
+            im = Image.open(BytesIO(contents))
+        except OSError:
+            stale = cache.open_image(include_stale=True)
+            if stale is not None:
+                return stale
             return False
-        except IOError:
-            pass
-    return im
+        if "dead_tile" in this_layer and _is_dead_tile(contents, this_layer["dead_tile"]):
+            cache.mark_tne()
+            return False
+        if this_layer.get("cached", True):
+            cache.write_bytes(contents)
+        return im
+    finally:
+        if locked:
+            cache.release()
+
+
+def _is_dead_tile(contents, dead_tile):
+    if isinstance(dead_tile, dict):
+        if "size" in dead_tile and len(contents) != dead_tile["size"]:
+            return False
+        if "md5" in dead_tile:
+            md5 = hashlib.md5(contents).hexdigest()
+            if md5 not in dead_tile["md5"]:
+                return False
+        if "sha256" in dead_tile:
+            sha256 = hashlib.sha256(contents).hexdigest()
+            if sha256 != dead_tile["sha256"]:
+                return False
+        return True
+    try:
+        return contents == open(dead_tile, "rb").read()
+    except IOError:
+        return False

--- a/twms/fetchers.py
+++ b/twms/fetchers.py
@@ -128,7 +128,7 @@ class TileCache:
         if not self.cached:
             return
         tmp_path = self.path + ".tmp.%s" % os.getpid()
-        image.save(tmp_path)
+        image.save(tmp_path, _EXTENSION_FORMATS.get(self.layer["ext"].lower()))
         os.replace(tmp_path, self.path)
         if os.path.exists(self.tne_path):
             os.remove(self.tne_path)

--- a/twms/fetchers.py
+++ b/twms/fetchers.py
@@ -36,6 +36,13 @@ _EXTENSION_FORMATS = {
 }
 
 
+def _layer_extension(this_layer):
+    if "ext" in this_layer:
+        return this_layer["ext"].lower().strip(".").replace("jpeg", "jpg")
+    mimetype = this_layer.get("mimetype", "image/jpeg")
+    return mimetype.lower().replace("image/", "").replace("jpeg", "jpg")
+
+
 def _cache_stem(z, x, y, this_layer):
     cache_prefix = config.tiles_cache + this_layer["prefix"]
     if this_layer.get("cache_layout") in ("zxy", "slippy", "mobac", "tms"):
@@ -137,7 +144,7 @@ class TileCache:
         self.cached = this_layer.get("cached", True)
         if self.cached:
             self.stem = _cache_stem(z, x, y, this_layer)
-            self.path = self.stem + this_layer["ext"]
+            self.path = self.stem + _layer_extension(this_layer)
             self.tne_path = self.stem + "tne"
             self.lock_path = self.stem + "lock"
         else:
@@ -209,7 +216,7 @@ class TileCache:
         if not self.cached:
             return
         tmp_path = self.path + ".tmp.%s" % os.getpid()
-        image.save(tmp_path, _EXTENSION_FORMATS.get(self.layer["ext"].lower()))
+        image.save(tmp_path, _EXTENSION_FORMATS.get(_layer_extension(self.layer)))
         os.replace(tmp_path, self.path)
         if os.path.exists(self.tne_path):
             os.remove(self.tne_path)
@@ -353,7 +360,7 @@ def Tile(z, x, y, this_layer):
             cache.mark_tne()
             return False
         if this_layer.get("cached", True):
-            cache.write_bytes(_cache_image_bytes(contents, im, this_layer["ext"]))
+            cache.write_bytes(_cache_image_bytes(contents, im, _layer_extension(this_layer)))
         return im
     finally:
         if locked:

--- a/twms/fetchers.py
+++ b/twms/fetchers.py
@@ -242,7 +242,7 @@ def Tile(z, x, y, this_layer):
     if "transform_tile_number" in this_layer:
         d_tuple = this_layer["transform_tile_number"](z, x, y)
 
-    remote = this_layer["remote_url"] % d_tuple
+    remote = _format_tile_url(this_layer["remote_url"], d_tuple)
     cache = TileCache(z, x, y, this_layer)
     if this_layer.get("cached", True) and not cache.needs_fetch():
         return cache.open_image()
@@ -313,6 +313,38 @@ def _cache_image_bytes(contents, image, extension):
     else:
         image.save(image_content, target_format)
     return image_content.getvalue()
+
+
+def _format_tile_url(template, tile):
+    if "{" not in template:
+        return template % tile
+
+    z, x, y = tile
+    return (
+        template.replace("{z}", str(z))
+        .replace("{x}", str(x))
+        .replace("{y}", str(y))
+        .replace("{-y}", str(tile_slippy_to_tms(z, x, y)[2]))
+        .replace("{q}", tile_to_quadkey(z, x, y))
+    )
+
+
+def tile_to_quadkey(z, x, y):
+    quadkey = []
+    for offset in range(z):
+        bit = z - offset
+        digit = ord("0")
+        mask = 1 << (bit - 1)
+        if x & mask:
+            digit += 1
+        if y & mask:
+            digit += 2
+        quadkey.append(chr(digit))
+    return "".join(quadkey)
+
+
+def tile_slippy_to_tms(z, x, y):
+    return z, x, (1 << z) - y - 1
 
 
 def _is_tne_http_error(error, this_layer):

--- a/twms/fetchers.py
+++ b/twms/fetchers.py
@@ -59,6 +59,26 @@ def _outside_zoom_limits(z, this_layer):
     return False
 
 
+def _format_wms_url(template, bbox, width, height, projection):
+    if any(
+        placeholder in template
+        for placeholder in ("{bbox}", "{width}", "{height}", "{proj}")
+    ):
+        return (
+            template.replace("{bbox}", bbox)
+            .replace("{width}", str(width))
+            .replace("{height}", str(height))
+            .replace("{proj}", projection)
+        )
+
+    return template + "bbox=%s&width=%s&height=%s&srs=%s" % (
+        bbox,
+        width,
+        height,
+        projection,
+    )
+
+
 class TileCache:
     """Small filesystem cache helper.
 
@@ -199,16 +219,15 @@ def threadwrapper(z, x, y, this_layer, zhash):
 def WMS(z, x, y, this_layer):
     if _outside_zoom_limits(z, this_layer):
         return None
-    wms = this_layer["remote_url"]
     req_proj = this_layer.get("wms_proj", this_layer["proj"])
     width = 384  # using larger source size to rescale better in python
     height = 384
     cache = TileCache(z, x, y, this_layer)
-    tile_bbox = "bbox=%s,%s,%s,%s" % tuple(
+    tile_bbox = "%s,%s,%s,%s" % tuple(
         projections.from4326(projections.bbox_by_tile(z, x, y, req_proj), req_proj)
     )
 
-    wms += tile_bbox + "&width=%s&height=%s&srs=%s" % (width, height, req_proj)
+    wms = _format_wms_url(this_layer["remote_url"], tile_bbox, width, height, req_proj)
     if this_layer.get("cached", True) and not cache.needs_fetch():
         return cache.open_image()
     locked = False

--- a/twms/fetchers.py
+++ b/twms/fetchers.py
@@ -36,10 +36,11 @@ _EXTENSION_FORMATS = {
 
 
 def _cache_stem(z, x, y, this_layer):
+    cache_prefix = config.tiles_cache + this_layer["prefix"]
+    if this_layer.get("cache_layout") in ("zxy", "slippy", "mobac", "tms"):
+        return cache_prefix + "/%s/%s/%s." % (z, x, y)
     return (
-        config.tiles_cache
-        + this_layer["prefix"]
-        + "/z%s/%s/x%s/%s/y%s." % (z, x // 1024, x, y // 1024, y)
+        cache_prefix + "/z%s/%s/x%s/%s/y%s." % (z, x // 1024, x, y // 1024, y)
     )
 
 

--- a/twms/fetchers.py
+++ b/twms/fetchers.py
@@ -51,6 +51,23 @@ def _upstream_request(url, this_layer):
     return url
 
 
+def _upstream_timeout(this_layer):
+    if "timeout" in this_layer:
+        return this_layer["timeout"]
+    return getattr(
+        config,
+        "upstream_timeout",
+        min(getattr(config, "deadline", 30), 30),
+    )
+
+
+def _read_upstream(url, this_layer):
+    return urlopen(
+        _upstream_request(url, this_layer),
+        timeout=_upstream_timeout(this_layer),
+    ).read()
+
+
 def _outside_zoom_limits(z, this_layer):
     if "min_zoom" in this_layer and z < this_layer["min_zoom"]:
         return True
@@ -238,7 +255,7 @@ def WMS(z, x, y, this_layer):
             return cache.wait_for_peer()
     try:
         try:
-            contents = urlopen(_upstream_request(wms, this_layer)).read()
+            contents = _read_upstream(wms, this_layer)
             im = _open_downloaded_image(contents)
             if im is None:
                 raise OSError
@@ -287,7 +304,7 @@ def Tile(z, x, y, this_layer):
             return cache.wait_for_peer()
     try:
         try:
-            contents = urlopen(_upstream_request(remote, this_layer)).read()
+            contents = _read_upstream(remote, this_layer)
             im = _open_downloaded_image(contents)
             if im is None:
                 raise OSError

--- a/twms/filter.py
+++ b/twms/filter.py
@@ -16,7 +16,7 @@ except ImportError:
     NUMPY_AVAILABLE = False
 import datetime
 
-from twms import getimg
+from twms.twms import getimg
 
 
 try:

--- a/twms/image_compat.py
+++ b/twms/image_compat.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+#    This file is part of twms.
+
+# This program is free software. It comes without any warranty, to
+# the extent permitted by applicable law. You can redistribute it
+# and/or modify it under the terms specified in COPYING.
+
+
+def resampling_lanczos(Image):
+    """Return the best Pillow downsampling filter across old and new Pillow."""
+    if hasattr(Image, "Resampling"):
+        return Image.Resampling.LANCZOS
+    return Image.ANTIALIAS

--- a/twms/josm.py
+++ b/twms/josm.py
@@ -28,17 +28,63 @@ def _layer_url(ref, layer_name, layer):
     )
 
 
+def _layer_bounds(config, layer):
+    return layer.get(
+        "data_bounding_box",
+        layer.get("bounds", layer.get("bbox", config.default_bbox)),
+    )
+
+
+def _dead_tile_md5_values(layer):
+    dead_tile = layer.get("dead_tile")
+    if not isinstance(dead_tile, dict) or "md5" not in dead_tile:
+        return ()
+    md5 = dead_tile["md5"]
+    if isinstance(md5, str):
+        return (md5,)
+    try:
+        return tuple(sorted(md5))
+    except TypeError:
+        return ()
+
+
 def document(config, ref):
     root = ET.Element(_tag("imagery"))
     for layer_name in sorted(config.layers):
         layer = config.layers[layer_name]
-        entry = ET.SubElement(root, _tag("entry"))
+        attrs = {}
+        if layer.get("overlay"):
+            attrs["overlay"] = "true"
+        entry = ET.SubElement(root, _tag("entry"), attrs)
+        ET.SubElement(entry, _tag("default")).text = "true"
         ET.SubElement(entry, _tag("name")).text = layer.get("name", layer_name)
         ET.SubElement(entry, _tag("id")).text = "twms-%s" % layer_name
         ET.SubElement(entry, _tag("type")).text = "tms"
         ET.SubElement(entry, _tag("url")).text = _layer_url(ref, layer_name, layer)
+        ET.SubElement(entry, _tag("description")).text = layer.get("name", layer_name)
+        bounds = _layer_bounds(config, layer)
+        ET.SubElement(
+            entry,
+            _tag("bounds"),
+            {
+                "min-lon": str(bounds[0]),
+                "min-lat": str(bounds[1]),
+                "max-lon": str(bounds[2]),
+                "max-lat": str(bounds[3]),
+            },
+        )
+        ET.SubElement(entry, _tag("valid-georeference")).text = "true"
         if "provider_url" in layer:
             ET.SubElement(entry, _tag("attribution-url")).text = layer["provider_url"]
+        for md5 in _dead_tile_md5_values(layer):
+            ET.SubElement(
+                entry,
+                _tag("no-tile-checksum"),
+                {
+                    "type": "MD5",
+                    "value": md5,
+                },
+            )
         if "max_zoom" in layer:
             ET.SubElement(entry, _tag("max-zoom")).text = str(layer["max_zoom"] - 1)
         if "min_zoom" in layer:

--- a/twms/josm.py
+++ b/twms/josm.py
@@ -17,7 +17,10 @@ def _tag(name):
 
 
 def _layer_extension(layer):
-    return layer.get("ext", "jpg").lower().replace("jpeg", "jpg")
+    return layer.get(
+        "ext",
+        layer.get("mimetype", "image/jpeg").lower().replace("image/", ""),
+    ).lower().replace("jpeg", "jpg")
 
 
 def _layer_url(ref, layer_name, layer):

--- a/twms/josm.py
+++ b/twms/josm.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+#    This file is part of twms.
+
+# This program is free software. It comes without any warranty, to
+# the extent permitted by applicable law. You can redistribute it
+# and/or modify it under the terms specified in COPYING.
+
+import xml.etree.ElementTree as ET
+
+
+JOSM_MAPS = "http://josm.openstreetmap.de/maps-1.0"
+ET.register_namespace("", JOSM_MAPS)
+
+
+def _tag(name):
+    return "{%s}%s" % (JOSM_MAPS, name)
+
+
+def _layer_extension(layer):
+    return layer.get("ext", "jpg").lower().replace("jpeg", "jpg")
+
+
+def _layer_url(ref, layer_name, layer):
+    return "%s%s/{zoom}/{x}/{y}.%s" % (
+        ref,
+        layer_name,
+        _layer_extension(layer),
+    )
+
+
+def document(config, ref):
+    root = ET.Element(_tag("imagery"))
+    for layer_name in sorted(config.layers):
+        layer = config.layers[layer_name]
+        entry = ET.SubElement(root, _tag("entry"))
+        ET.SubElement(entry, _tag("name")).text = layer.get("name", layer_name)
+        ET.SubElement(entry, _tag("id")).text = "twms-%s" % layer_name
+        ET.SubElement(entry, _tag("type")).text = "tms"
+        ET.SubElement(entry, _tag("url")).text = _layer_url(ref, layer_name, layer)
+        if "provider_url" in layer:
+            ET.SubElement(entry, _tag("attribution-url")).text = layer["provider_url"]
+        if "max_zoom" in layer:
+            ET.SubElement(entry, _tag("max-zoom")).text = str(layer["max_zoom"] - 1)
+        if "min_zoom" in layer:
+            ET.SubElement(entry, _tag("min-zoom")).text = str(layer["min_zoom"])
+    return root
+
+
+def xml(config, ref):
+    return ET.tostring(document(config, ref), encoding="unicode", xml_declaration=True)

--- a/twms/overview.py
+++ b/twms/overview.py
@@ -16,6 +16,13 @@ def _layer_bounds(layer):
     )
 
 
+def _layer_extension(layer):
+    return layer.get(
+        "ext",
+        layer.get("mimetype", "image/jpeg").lower().replace("image/", ""),
+    ).lower().replace("jpeg", "jpg")
+
+
 def html(ref):
     """
     Gives overall information about twms server and its layers in HTML format.
@@ -59,7 +66,7 @@ def html(ref):
             + ""
             + i
             + "/!/!/!."
-            + layers[i].get("ext", "jpg")
+            + _layer_extension(layers[i])
             + "<br />"
         )
         resp += "</td></tr>"

--- a/twms/overview.py
+++ b/twms/overview.py
@@ -9,6 +9,13 @@ import projections
 from config import *
 
 
+def _layer_bounds(layer):
+    return layer.get(
+        "data_bounding_box",
+        layer.get("bounds", projections.projs[layer["proj"]]["bounds"]),
+    )
+
+
 def html(ref):
     """
     Gives overall information about twms server and its layers in HTML format.
@@ -20,9 +27,7 @@ def html(ref):
     resp += wms_name
     resp += "</h2><table>"
     for i in layers:
-        bbox = layers[i].get(
-            "data_bounding_box", projections.projs[layers[i]["proj"]]["bounds"]
-        )
+        bbox = _layer_bounds(layers[i])
         resp += '<tr><td><img src="'
         resp += (
             ref
@@ -31,7 +36,14 @@ def html(ref):
             + "&amp;bbox=%s,%s,%s,%s" % bbox
             + '&amp;width=200&amp;format=image/png" width="200" /></td><td><h3>'
         )
-        resp += layers[i]["name"]
+        if "provider_url" in layers[i]:
+            resp += '<a referrerpolicy="no-referrer" href="'
+            resp += layers[i]["provider_url"]
+            resp += '">'
+            resp += layers[i]["name"]
+            resp += "</a>"
+        else:
+            resp += layers[i]["name"]
         resp += (
             "</h3><b>Bounding box:</b> "
             + str(bbox)

--- a/twms/projections.py
+++ b/twms/projections.py
@@ -15,13 +15,21 @@ except ImportError:
             def __init__(self, pstring):
                 self.pstring = pstring
 
-        def transform(self, pr1, pr2, c1, c2):
+        @staticmethod
+        def transform(pr1, pr2, c1, c2):
             if pr1.pstring == pr2.pstring:
                 return c1, c2
             else:
                 raise NotImplementedError(
-                    "Pyproj is not installed - can't convert between projectios. Install pyproj please."
+                    "Pyproj is not installed - can't convert between projections. Install twms[proj] please."
                 )
+
+
+def _pyproj_transformer(pr1, pr2):
+    if hasattr(pyproj, "Transformer"):
+        transformer = pyproj.Transformer.from_proj(pr1, pr2, always_xy=True)
+        return lambda _pr1, _pr2, c1, c2: transformer.transform(c1, c2)
+    return pyproj.transform
 
 
 projs = {
@@ -101,13 +109,17 @@ def _c4326t3857(t1, t2, lon, lat):
     """
     Pure python 4326 -> 3857 transform. About 8x faster than pyproj.
     """
+    maxbounds = 6378137 * math.pi
+    xtile = maxbounds / 180 * lon
     lat_rad = math.radians(lat)
-    xtile = lon * 111319.49079327358
-    ytile = (
-        math.log(math.tan(lat_rad) + (1 / math.cos(lat_rad)))
-        / math.pi
-        * 20037508.342789244
-    )
+    if abs(lat) <= 85.0511287798:
+        ytile = (
+            math.log(math.tan(lat_rad) + (1 / math.cos(lat_rad)))
+            / math.pi
+            * maxbounds
+        )
+    else:
+        ytile = math.copysign(maxbounds, lat)
     return (xtile, ytile)
 
 
@@ -269,9 +281,10 @@ def transform(line, srs1, srs2):
     if (srs1, srs2) in pure_python_transformers:
         func = pure_python_transformers[(srs1, srs2)]
         # print("pure")
+        uses_pyproj = False
     else:
-
-        func = pyproj.transform
+        func = None
+        uses_pyproj = True
     line = list(line)
     serial = False
     if (not isinstance(line[0], tuple)) and (not isinstance(line[0], list)):
@@ -285,6 +298,8 @@ def transform(line, srs1, srs2):
     ans = []
     pr1 = projs[srs1]["proj"]
     pr2 = projs[srs2]["proj"]
+    if uses_pyproj:
+        func = _pyproj_transformer(pr1, pr2)
     for point in line:
         p = func(pr1, pr2, point[0], point[1])
         if serial:

--- a/twms/projections.py
+++ b/twms/projections.py
@@ -102,7 +102,11 @@ projs = {
         "bounds": (-180.0, -90.0, 180.0, 90.0),
     },
 }
-proj_alias = {"EPSG:900913": "EPSG:3857", "EPSG:3785": "EPSG:3857"}
+proj_alias = {
+    "CRS:84": "EPSG:4326",
+    "EPSG:900913": "EPSG:3857",
+    "EPSG:3785": "EPSG:3857",
+}
 
 
 def _c4326t3857(t1, t2, lon, lat):

--- a/twms/server.py
+++ b/twms/server.py
@@ -16,6 +16,10 @@ from twms import twms_main
 
 tile_route = re.compile(r"/(.*)/([0-9]+)/([0-9]+)/([0-9]+)(\.[a-zA-Z]+)?(.*)")
 tilejson_route = re.compile(r"/tilejson/(.*)\.json")
+wmts_capabilities_route = "/wmts/1.0.0/WMTSCapabilities.xml"
+wmts_tile_route = re.compile(
+    r"/wmts/([^/]+)/([0-9]+)/([0-9]+)/([0-9]+)(\.[a-zA-Z]+)?"
+)
 
 
 def request_url(handler):
@@ -34,8 +38,13 @@ def dispatch(path, ref=None):
             "request": "GetTileJSON",
             "layers": urllib.parse.unquote(tilejson_match.group(1)),
         }
+    elif parsed.path == wmts_capabilities_route:
+        data = {
+            "request": "GetCapabilities",
+            "service": "WMTS",
+        }
     else:
-        match = tile_route.fullmatch(parsed.path)
+        match = wmts_tile_route.fullmatch(parsed.path)
         if match:
             ext = match.group(5) or ".jpg"
             data = {
@@ -47,8 +56,20 @@ def dispatch(path, ref=None):
                 "y": match.group(4),
             }
         else:
-            data = dict(urllib.parse.parse_qsl(parsed.query))
-            data = dict((key.lower(), data[key]) for key in data)
+            match = tile_route.fullmatch(parsed.path)
+            if match:
+                ext = match.group(5) or ".jpg"
+                data = {
+                    "request": "GetTile",
+                    "layers": match.group(1),
+                    "format": ext.strip(".").lower(),
+                    "z": match.group(2),
+                    "x": match.group(3),
+                    "y": match.group(4),
+                }
+            else:
+                data = dict(urllib.parse.parse_qsl(parsed.query))
+                data = dict((key.lower(), data[key]) for key in data)
 
     if ref and "ref" not in data:
         data["ref"] = ref

--- a/twms/server.py
+++ b/twms/server.py
@@ -15,6 +15,7 @@ from twms import twms_main
 
 
 tile_route = re.compile(r"/(.*)/([0-9]+)/([0-9]+)/([0-9]+)(\.[a-zA-Z]+)?(.*)")
+tilejson_route = re.compile(r"/tilejson/(.*)\.json")
 
 
 def request_url(handler):
@@ -27,20 +28,27 @@ def request_url(handler):
 
 def dispatch(path, ref=None):
     parsed = urllib.parse.urlsplit(path)
-    match = tile_route.fullmatch(parsed.path)
-    if match:
-        ext = match.group(5) or ".jpg"
+    tilejson_match = tilejson_route.fullmatch(parsed.path)
+    if tilejson_match:
         data = {
-            "request": "GetTile",
-            "layers": match.group(1),
-            "format": ext.strip(".").lower(),
-            "z": match.group(2),
-            "x": match.group(3),
-            "y": match.group(4),
+            "request": "GetTileJSON",
+            "layers": urllib.parse.unquote(tilejson_match.group(1)),
         }
     else:
-        data = dict(urllib.parse.parse_qsl(parsed.query))
-        data = dict((key.lower(), data[key]) for key in data)
+        match = tile_route.fullmatch(parsed.path)
+        if match:
+            ext = match.group(5) or ".jpg"
+            data = {
+                "request": "GetTile",
+                "layers": match.group(1),
+                "format": ext.strip(".").lower(),
+                "z": match.group(2),
+                "x": match.group(3),
+                "y": match.group(4),
+            }
+        else:
+            data = dict(urllib.parse.parse_qsl(parsed.query))
+            data = dict((key.lower(), data[key]) for key in data)
 
     if ref and "ref" not in data:
         data["ref"] = ref

--- a/twms/server.py
+++ b/twms/server.py
@@ -15,8 +15,11 @@ from twms import twms_main
 
 
 tile_route = re.compile(r"/(.*)/([0-9]+)/([0-9]+)/([0-9]+)(\.[a-zA-Z]+)?(.*)")
+wms_tile_route = re.compile(
+    r"/wms/([^/]+)/([0-9]+)/([0-9]+)/([0-9]+)(\.[a-zA-Z]+)?"
+)
 tilejson_route = re.compile(r"/tilejson/(.+)\.json")
-josm_imagery_routes = {"/josm/imagery.xml", "/maps.xml"}
+josm_imagery_routes = {"/josm/imagery.xml", "/josm/maps.xml", "/maps.xml"}
 wmts_capabilities_route = "/wmts/1.0.0/WMTSCapabilities.xml"
 wmts_tile_route = re.compile(
     r"/wmts/([^/]+)/([0-9]+)/([0-9]+)/([0-9]+)(\.[a-zA-Z]+)?"
@@ -29,6 +32,18 @@ def request_url(handler):
     if not host:
         host = "%s:%s" % handler.server.server_address[:2]
     return "%s://%s/" % (scheme, host)
+
+
+def _tile_data(match):
+    ext = match.group(5) or ".jpg"
+    return {
+        "request": "GetTile",
+        "layers": match.group(1),
+        "format": ext.strip(".").lower(),
+        "z": match.group(2),
+        "x": match.group(3),
+        "y": match.group(4),
+    }
 
 
 def dispatch(path, ref=None):
@@ -49,34 +64,24 @@ def dispatch(path, ref=None):
             "service": "WMTS",
         }
     else:
-        match = wmts_tile_route.fullmatch(parsed.path)
+        match = wms_tile_route.fullmatch(parsed.path)
         if match:
-            ext = match.group(5) or ".jpg"
-            data = {
-                "request": "GetTile",
-                "layers": match.group(1),
-                "format": ext.strip(".").lower(),
-                "z": match.group(2),
-                "x": match.group(3),
-                "y": match.group(4),
-            }
+            data = _tile_data(match)
         else:
-            match = tile_route.fullmatch(parsed.path)
+            match = wmts_tile_route.fullmatch(parsed.path)
             if match:
-                ext = match.group(5) or ".jpg"
-                data = {
-                    "request": "GetTile",
-                    "layers": match.group(1),
-                    "format": ext.strip(".").lower(),
-                    "z": match.group(2),
-                    "x": match.group(3),
-                    "y": match.group(4),
-                }
+                data = _tile_data(match)
             else:
-                if not parsed.query and parsed.path not in ("", "/"):
-                    return 404, "text/plain", "Not Found\n"
-                data = dict(urllib.parse.parse_qsl(parsed.query))
-                data = dict((key.lower(), data[key]) for key in data)
+                match = tile_route.fullmatch(parsed.path)
+                if match:
+                    data = _tile_data(match)
+                else:
+                    if not parsed.query and parsed.path not in ("", "/", "/wms"):
+                        return 404, "text/plain", "Not Found\n"
+                    data = dict(urllib.parse.parse_qsl(parsed.query))
+                    data = dict((key.lower(), data[key]) for key in data)
+                    if ref and parsed.path == "/wms":
+                        ref = urllib.parse.urljoin(ref, "wms")
 
     if ref and "ref" not in data:
         data["ref"] = ref

--- a/twms/server.py
+++ b/twms/server.py
@@ -15,7 +15,7 @@ from twms import twms_main
 
 
 tile_route = re.compile(r"/(.*)/([0-9]+)/([0-9]+)/([0-9]+)(\.[a-zA-Z]+)?(.*)")
-tilejson_route = re.compile(r"/tilejson/(.*)\.json")
+tilejson_route = re.compile(r"/tilejson/(.+)\.json")
 josm_imagery_routes = {"/josm/imagery.xml", "/maps.xml"}
 wmts_capabilities_route = "/wmts/1.0.0/WMTSCapabilities.xml"
 wmts_tile_route = re.compile(
@@ -73,6 +73,8 @@ def dispatch(path, ref=None):
                     "y": match.group(4),
                 }
             else:
+                if not parsed.query and parsed.path not in ("", "/"):
+                    return 404, "text/plain", "Not Found\n"
                 data = dict(urllib.parse.parse_qsl(parsed.query))
                 data = dict((key.lower(), data[key]) for key in data)
 

--- a/twms/server.py
+++ b/twms/server.py
@@ -16,6 +16,7 @@ from twms import twms_main
 
 tile_route = re.compile(r"/(.*)/([0-9]+)/([0-9]+)/([0-9]+)(\.[a-zA-Z]+)?(.*)")
 tilejson_route = re.compile(r"/tilejson/(.*)\.json")
+josm_imagery_routes = {"/josm/imagery.xml", "/maps.xml"}
 wmts_capabilities_route = "/wmts/1.0.0/WMTSCapabilities.xml"
 wmts_tile_route = re.compile(
     r"/wmts/([^/]+)/([0-9]+)/([0-9]+)/([0-9]+)(\.[a-zA-Z]+)?"
@@ -37,6 +38,10 @@ def dispatch(path, ref=None):
         data = {
             "request": "GetTileJSON",
             "layers": urllib.parse.unquote(tilejson_match.group(1)),
+        }
+    elif parsed.path in josm_imagery_routes:
+        data = {
+            "request": "GetJOSMImagery",
         }
     elif parsed.path == wmts_capabilities_route:
         data = {

--- a/twms/server.py
+++ b/twms/server.py
@@ -1,0 +1,82 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+#    This file is part of twms.
+
+# This program is free software. It comes without any warranty, to
+# the extent permitted by applicable law. You can redistribute it
+# and/or modify it under the terms specified in COPYING.
+
+import re
+import sys
+import urllib.parse
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from twms import twms_main
+
+
+tile_route = re.compile(r"/(.*)/([0-9]+)/([0-9]+)/([0-9]+)(\.[a-zA-Z]+)?(.*)")
+
+
+def request_url(handler):
+    scheme = "http"
+    host = handler.headers.get("Host")
+    if not host:
+        host = "%s:%s" % handler.server.server_address[:2]
+    return "%s://%s/" % (scheme, host)
+
+
+def dispatch(path, ref=None):
+    parsed = urllib.parse.urlsplit(path)
+    match = tile_route.fullmatch(parsed.path)
+    if match:
+        ext = match.group(5) or ".jpg"
+        data = {
+            "request": "GetTile",
+            "layers": match.group(1),
+            "format": ext.strip(".").lower(),
+            "z": match.group(2),
+            "x": match.group(3),
+            "y": match.group(4),
+        }
+    else:
+        data = dict(urllib.parse.parse_qsl(parsed.query))
+        data = dict((key.lower(), data[key]) for key in data)
+
+    if ref and "ref" not in data:
+        data["ref"] = ref
+    return twms_main(data)
+
+
+class TWMSRequestHandler(BaseHTTPRequestHandler):
+    server_version = "twms"
+
+    def do_GET(self):
+        status, content_type, content = dispatch(self.path, request_url(self))
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        if "text/" in content_type or "xml" in content_type:
+            self.send_header("Cache-Control", "no-cache, no-store, must-revalidate")
+            self.send_header("Pragma", "no-cache")
+            self.send_header("Expires", "0")
+        self.end_headers()
+        if isinstance(content, str):
+            content = content.encode("utf-8")
+        self.wfile.write(content)
+
+    def log_message(self, format, *args):
+        pass
+
+
+def main():
+    try:
+        port = int(sys.argv[1])
+    except IndexError:
+        port = 8080
+
+    server = ThreadingHTTPServer(("", port), TWMSRequestHandler)
+    print("TWMS server listening on port %s" % port)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/twms/server.py
+++ b/twms/server.py
@@ -8,10 +8,11 @@
 
 import re
 import sys
+import textwrap
 import urllib.parse
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
-from twms import twms_main
+from twms import __version__, twms_main
 
 
 tile_route = re.compile(r"/(.*)/([0-9]+)/([0-9]+)/([0-9]+)(\.[a-zA-Z]+)?(.*)")
@@ -32,6 +33,28 @@ def request_url(handler):
     if not host:
         host = "%s:%s" % handler.server.server_address[:2]
     return "%s://%s/" % (scheme, host)
+
+
+def startup_banner(bind_host, port):
+    url_host = bind_host
+    if not url_host or url_host in ("0.0.0.0", "::"):
+        url_host = "127.0.0.1"
+    base = "http://%s:%s" % (url_host, port)
+    return textwrap.dedent(
+        """\
+        TWMS server {version} listening on {bind_host}:{port}
+        Overview: {base}/
+        WMS: {base}/wms?SERVICE=WMS&REQUEST=GetCapabilities
+        WMTS: {base}/wmts/1.0.0/WMTSCapabilities.xml
+        JOSM imagery: {base}/josm/maps.xml
+        Press Ctrl-C to stop
+        """
+    ).format(
+        version=__version__,
+        bind_host=bind_host or "0.0.0.0",
+        port=port,
+        base=base,
+    ).rstrip()
 
 
 def _tile_data(match):
@@ -89,7 +112,7 @@ def dispatch(path, ref=None):
 
 
 class TWMSRequestHandler(BaseHTTPRequestHandler):
-    server_version = "twms"
+    server_version = "twms/%s" % __version__
 
     def do_GET(self):
         status, content_type, content = dispatch(self.path, request_url(self))
@@ -109,13 +132,14 @@ class TWMSRequestHandler(BaseHTTPRequestHandler):
 
 
 def main():
+    host = ""
     try:
         port = int(sys.argv[1])
     except IndexError:
         port = 8080
 
-    server = ThreadingHTTPServer(("", port), TWMSRequestHandler)
-    print("TWMS server listening on port %s" % port)
+    server = ThreadingHTTPServer((host, port), TWMSRequestHandler)
+    print(startup_banner(host, port))
     server.serve_forever()
 
 

--- a/twms/tilejson.py
+++ b/twms/tilejson.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+#    This file is part of twms.
+
+# This program is free software. It comes without any warranty, to
+# the extent permitted by applicable law. You can redistribute it
+# and/or modify it under the terms specified in COPYING.
+
+import json
+
+import bbox
+
+
+def _layer_names(config, layers):
+    names = [name for name in layers.split(",") if name]
+    if not names:
+        names = [name for name in config.default_layers.split(",") if name]
+    if not names:
+        raise KeyError("TileJSON needs an existing layer name")
+    for name in names:
+        if name not in config.layers:
+            raise KeyError("Unknown layer: %s" % name)
+    return names
+
+
+def _layer_bounds(config, layer):
+    return layer.get(
+        "data_bounding_box",
+        layer.get("bbox", config.default_bbox),
+    )
+
+
+def _tile_extension(config, layer_names, format_name):
+    if format_name:
+        return format_name.lower().replace("image/", "").replace("jpeg", "jpg")
+    if len(layer_names) == 1:
+        return config.layers[layer_names[0]].get("ext", "jpg")
+    return config.default_format.lower().replace("image/", "").replace("jpeg", "jpg")
+
+
+def document(config, layers, ref, format_name=""):
+    layer_names = _layer_names(config, layers)
+    layer_items = [config.layers[name] for name in layer_names]
+    bounds = _layer_bounds(config, layer_items[0])
+    for layer in layer_items[1:]:
+        bounds = bbox.add(bounds, _layer_bounds(config, layer))
+
+    minzoom = max(layer.get("min_zoom", 0) for layer in layer_items)
+    maxzoom = min(layer.get("max_zoom", config.default_max_zoom) for layer in layer_items)
+    center = [
+        (bounds[0] + bounds[2]) / 2.0,
+        (bounds[1] + bounds[3]) / 2.0,
+        minzoom,
+    ]
+    ext = _tile_extension(config, layer_names, format_name)
+    tile_url = "%s%s/{z}/{x}/{y}.%s" % (ref, ",".join(layer_names), ext)
+
+    return {
+        "tilejson": "3.0.0",
+        "name": ", ".join(layer["name"] for layer in layer_items),
+        "scheme": "xyz",
+        "tiles": [tile_url],
+        "bounds": list(bounds),
+        "center": center,
+        "minzoom": minzoom,
+        "maxzoom": maxzoom,
+    }
+
+
+def dumps(config, layers, ref, format_name=""):
+    return json.dumps(
+        document(config, layers, ref, format_name=format_name),
+        sort_keys=True,
+    )

--- a/twms/tilejson.py
+++ b/twms/tilejson.py
@@ -25,7 +25,7 @@ def _layer_names(config, layers):
 def _layer_bounds(config, layer):
     return layer.get(
         "data_bounding_box",
-        layer.get("bbox", config.default_bbox),
+        layer.get("bounds", layer.get("bbox", config.default_bbox)),
     )
 
 

--- a/twms/tilejson.py
+++ b/twms/tilejson.py
@@ -33,7 +33,14 @@ def _tile_extension(config, layer_names, format_name):
     if format_name:
         return format_name.lower().replace("image/", "").replace("jpeg", "jpg")
     if len(layer_names) == 1:
-        return config.layers[layer_names[0]].get("ext", "jpg")
+        layer = config.layers[layer_names[0]]
+        return layer.get(
+            "ext",
+            layer.get("mimetype", "image/jpeg")
+            .lower()
+            .replace("image/", "")
+            .replace("jpeg", "jpg"),
+        )
     return config.default_format.lower().replace("image/", "").replace("jpeg", "jpg")
 
 

--- a/twms/twms.conf
+++ b/twms/twms.conf
@@ -16,6 +16,8 @@ install_path = "/usr/share/twms/"                        # where to look for bro
 gpx_cache = "/var/cache/twms/traces/"                    # where to store cached OSM GPX files
 deadline = 45                                                # number of seconds that are given to make up image
 upstream_timeout = 30                                        # upstream HTTP timeout in seconds; layers may override with "timeout"
+upstream_retries = 1                                         # total upstream HTTP attempts; layers may override with "upstream_retries"
+upstream_retry_delay = 0                                     # seconds to wait between retry attempts; layers may override
 default_max_zoom = 18                                        # can be overridden per layer
 geometry_color = {                                           # default color for overlayed vectors
         "LINESTRING": "#ff0000",

--- a/twms/twms.conf
+++ b/twms/twms.conf
@@ -15,6 +15,7 @@ tiles_cache = "/var/cache/twms/tiles/"                   # where to put cache
 install_path = "/usr/share/twms/"                        # where to look for broken tiles and other stuff
 gpx_cache = "/var/cache/twms/traces/"                    # where to store cached OSM GPX files
 deadline = 45                                                # number of seconds that are given to make up image
+upstream_timeout = 30                                        # upstream HTTP timeout in seconds; layers may override with "timeout"
 default_max_zoom = 18                                        # can be overridden per layer
 geometry_color = {                                           # default color for overlayed vectors
         "LINESTRING": "#ff0000",

--- a/twms/twms.py
+++ b/twms/twms.py
@@ -34,6 +34,7 @@ from bbox import expand_to_point, zoom_for_bbox
 from gpxparse import GPXParser
 from PIL import Image, ImageColor, ImageOps
 from reproject import reproject
+from twms.image_compat import resampling_lanczos
 
 
 try:
@@ -82,7 +83,11 @@ def twms_main(data):
         gpx = []
     wkt = data.get("wkt", "")
     trackblend = float(data.get("trackblend", "0.5"))
-    color = data.get("color", data.get("colour", "")).split(",")
+    colors = [
+        value
+        for value in data.get("color", data.get("colour", "")).split(",")
+        if value
+    ]
     track = False
     tracks = []
     if len(gpx) == 0:
@@ -148,7 +153,7 @@ def twms_main(data):
         points = [a.split(",") for a in points]
         points = [(float(a[0]), float(a[1])) for a in points]
 
-        req.content_type = "text/plain"
+        content_type = "text/plain"
         for lay in layer:
             for point in points:
                 resp += "%s,%s;" % tuple(correctify.rectify(config.layers[lay], point))
@@ -298,13 +303,13 @@ def twms_main(data):
                             ):
                                 sec.add((ec[0] + tr, ec[1] + tg, ec[2] + tb, ec[3]))
             i2l = im2.load()
-            for x in range(0, im2.size[0]):
-                for y in range(0, im2.size[1]):
-                    t = i2l[x, y]
+            for px in range(0, im2.size[0]):
+                for py in range(0, im2.size[1]):
+                    t = i2l[px, py]
                     if t in sec:
-                        i2l[x, y] = (t[0], t[1], t[2], 0)
+                        i2l[px, py] = (t[0], t[1], t[2], 0)
         if not im2.size == result_img.size:
-            im2 = im2.resize(result_img.size, Image.ANTIALIAS)
+            im2 = im2.resize(result_img.size, resampling_lanczos(Image))
         im2 = Image.composite(im2, result_img, im2.split()[3])  # imgs/(imgs+1.))
 
         if "noblend" in force:
@@ -324,15 +329,15 @@ def twms_main(data):
             result_img,
             req_bbox,
             srs,
-            color if len(color) > 0 else None,
+            colors[0] if colors else None,
             trackblend,
         )
     if len(gpx) > 0:
         last_color = None
-        c = iter(color)
+        c = iter(colors)
         for track in tracks:
             try:
-                last_color = c.next()
+                last_color = next(c)
             except StopIteration:
                 pass
             result_img = drawing.gpx(
@@ -479,7 +484,7 @@ def tile_image(layer, z, x, y, start_time, again=False, trybetter=True, real=Fal
                                 im.paste(im2, (256, 0))
                                 im.paste(im3, (0, 256))
                                 im.paste(im4, (256, 256))
-                                im = im.resize((256, 256), Image.ANTIALIAS)
+                                im = im.resize((256, 256), resampling_lanczos(Image))
                                 if layer.get("cached", True):
                                     try:
                                         im.save(local + "ups." + ext)
@@ -640,6 +645,6 @@ def getimg(bbox, request_proj, size, layer, start_time, force):
         out = out.transform((W, H), Image.QUAD, quad, Image.BICUBIC)
     elif (W != out.size[0]) or (H != out.size[1]):
         "just resize"
-        out = out.resize((W, H), Image.ANTIALIAS)
+        out = out.resize((W, H), resampling_lanczos(Image))
     # out = reproject(out, bbox, layer["proj"], request_proj)
     return out

--- a/twms/twms.py
+++ b/twms/twms.py
@@ -12,6 +12,7 @@ import os
 import sys
 import time
 import urllib
+from collections import OrderedDict
 from io import BytesIO
 
 sys.path.append(os.path.join(os.path.dirname(__file__)))
@@ -49,8 +50,7 @@ except ImportError:
 OK = 200
 ERROR = 500
 
-cached_objs = {}  # a dict. (layer, z, x, y): PIL image
-cached_hist_list = []
+cached_objs = OrderedDict()  # (layer, z, x, y): PIL image, least-recent first
 
 formats = {
     "image/gif": "GIF",
@@ -61,6 +61,27 @@ formats = {
 }
 
 mimetypes = dict(zip(formats.values(), formats.keys()))
+
+
+def _ram_cache_key(layer, z, x, y):
+    return (layer["prefix"], z, x, y)
+
+
+def _ram_cache_get(key):
+    if key not in cached_objs:
+        return None
+    cached_objs.move_to_end(key)
+    return cached_objs[key]
+
+
+def _ram_cache_put(key, image):
+    limit = int(getattr(config, "max_ram_cached_tiles", 1024))
+    if limit <= 0:
+        return
+    cached_objs[key] = image
+    cached_objs.move_to_end(key)
+    while len(cached_objs) > limit:
+        cached_objs.popitem(last=False)
 
 
 def twms_main(data):
@@ -420,10 +441,11 @@ def tile_image(layer, z, x, y, start_time, again=False, trybetter=True, real=Fal
         fully=False,
     ):
         return None
-    global cached_objs, cached_hist_list
+    global cached_objs
     if "prefix" in layer:
-        if (layer["prefix"], z, x, y) in cached_objs:
-            return cached_objs[(layer["prefix"], z, x, y)]
+        cached = _ram_cache_get(_ram_cache_key(layer, z, x, y))
+        if cached is not None:
+            return cached
     if layer.get("cached", True):
         local = (
             config.tiles_cache
@@ -600,16 +622,12 @@ def getimg(bbox, request_proj, size, layer, start_time, force):
             im1 = tile_image(layer, zoom, x, y, start_time, real=True)
             if im1:
                 if "prefix" in layer:
-                    if (layer["prefix"], zoom, x, y) not in cached_objs:
+                    cache_key = _ram_cache_key(layer, zoom, x, y)
+                    if cache_key not in cached_objs:
                         if im1.is_ok:
-                            cached_objs[(layer["prefix"], zoom, x, y)] = im1
-                            cached_hist_list.append((layer["prefix"], zoom, x, y))
+                            _ram_cache_put(cache_key, im1)
                             # print((layer["prefix"], zoom, x, y), cached_objs[(layer["prefix"], zoom, x, y)], file=sys.stderr)
                             # sys.stderr.flush()
-                    if len(cached_objs) >= config.max_ram_cached_tiles:
-                        del cached_objs[cached_hist_list.pop(0)]
-                        # print("Removed tile from cache", file=sys.stderr)
-                        # sys.stderr.flush()
             else:
                 ec = ImageColor.getcolor(
                     layer.get("empty_color", config.default_background), "RGBA"

--- a/twms/twms.py
+++ b/twms/twms.py
@@ -58,6 +58,7 @@ formats = {
     "image/jpg": "JPEG",
     "image/png": "PNG",
     "image/bmp": "BMP",
+    "image/webp": "WEBP",
 }
 
 mimetypes = dict(zip(formats.values(), formats.keys()))

--- a/twms/twms.py
+++ b/twms/twms.py
@@ -234,7 +234,7 @@ def twms_main(data):
                         + config.layers[layer[0]]["prefix"]
                         + "/z%s/%s/x%s/%s/y%s." % (z, x / 1024, x, y / 1024, y)
                     )
-                    ext = config.layers[layer]["ext"]
+                    ext = config.layers[layer[0]]["ext"]
                     adds = ["", "ups."]
                     for add in adds:
                         if os.path.exists(local + add + ext):

--- a/twms/twms.py
+++ b/twms/twms.py
@@ -26,6 +26,7 @@ import capabilities
 import correctify
 import drawing
 import fetchers
+import josm
 import overview
 import projections
 import tilejson
@@ -142,6 +143,8 @@ def twms_main(data):
             return (OK, "application/json", resp)
         except KeyError as exc:
             return (400, "text/plain", str(exc))
+    if req_type_lower in ("getjosmimagery", "josmimagery", "getjosmmaps"):
+        return (OK, "text/xml", josm.xml(config, ref))
 
     layer = data.get("layers", config.default_layers).split(",")
     if ("layers" in data) and not layer[0]:

--- a/twms/twms.py
+++ b/twms/twms.py
@@ -7,7 +7,8 @@
 # and/or modify it under the terms specified in COPYING.
 
 import datetime
-import imp
+import importlib.machinery
+import importlib.util
 import math
 import os
 import sys
@@ -18,21 +19,27 @@ from io import BytesIO
 # import config
 sys.path.append(os.path.join(os.path.dirname(__file__)))
 
+
+def load_config(path):
+    loader = importlib.machinery.SourceFileLoader("twms.config", path)
+    spec = importlib.util.spec_from_loader("twms.config", loader)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["twms.config"] = module
+    sys.modules["config"] = module
+    loader.exec_module(module)
+    return module
+
+
 config_path = "/etc/twms/twms.conf"
 if os.path.exists(config_path):
-    try:
-        config = imp.load_source("twms.config", config_path)
-    except:
-        config = imp.load_source("config", config_path)
+    config = load_config(config_path)
 else:
     try:
         config_path = os.path.join(os.path.dirname(__file__), "twms.conf")
-        config = imp.load_source("twms.config", config_path)
+        config = load_config(config_path)
     except:
         config_path = os.path.join(os.path.realpath(sys.path[0]), "twms.conf")
-        config = imp.load_source(
-            "config", os.path.join(os.path.realpath(sys.path[0]), "twms.conf")
-        )
+        config = load_config(config_path)
     sys.stderr.write(
         "Configuration file not found, using defaults from %s\n" % config_path
     )

--- a/twms/twms.py
+++ b/twms/twms.py
@@ -290,19 +290,19 @@ def twms_main(data):
 
         if "empty_color" in config.layers[ll]:
             ec = ImageColor.getcolor(config.layers[ll]["empty_color"], "RGBA")
-            sec = set(ec)
+            sec = {ec}
             if "empty_color_delta" in config.layers[ll]:
                 delta = config.layers[ll]["empty_color_delta"]
-                for tr in range(-delta, delta):
-                    for tg in range(-delta, delta):
-                        for tb in range(-delta, delta):
+                for tr in range(-delta, delta + 1):
+                    for tg in range(-delta, delta + 1):
+                        for tb in range(-delta, delta + 1):
                             if (
                                 (ec[0] + tr) >= 0
                                 and (ec[0] + tr) < 256
-                                and (ec[1] + tr) >= 0
-                                and (ec[1] + tr) < 256
-                                and (ec[2] + tr) >= 0
-                                and (ec[2] + tr) < 256
+                                and (ec[1] + tg) >= 0
+                                and (ec[1] + tg) < 256
+                                and (ec[2] + tb) >= 0
+                                and (ec[2] + tb) < 256
                             ):
                                 sec.add((ec[0] + tr, ec[1] + tg, ec[2] + tb, ec[3]))
             i2l = im2.load()

--- a/twms/twms.py
+++ b/twms/twms.py
@@ -28,6 +28,7 @@ import drawing
 import fetchers
 import overview
 import projections
+import tilejson
 from bbox import expand_to_point, zoom_for_bbox
 from gpxparse import GPXParser
 from PIL import Image, ImageColor, ImageOps
@@ -109,6 +110,17 @@ def twms_main(data):
     if req_type == "GetCapabilities":
         content_type, resp = capabilities.get(version, ref)
         return (OK, content_type, resp)
+    if req_type.lower() in ("gettilejson", "tilejson"):
+        try:
+            resp = tilejson.dumps(
+                config,
+                data.get("layers", ""),
+                ref,
+                format_name=data.get("format", ""),
+            )
+            return (OK, "application/json", resp)
+        except KeyError as exc:
+            return (400, "text/plain", str(exc))
 
     layer = data.get("layers", config.default_layers).split(",")
     if ("layers" in data) and not layer[0]:

--- a/twms/twms.py
+++ b/twms/twms.py
@@ -84,6 +84,17 @@ def _ram_cache_put(key, image):
         cached_objs.popitem(last=False)
 
 
+def _response_cache_entry(
+    response_cache, srs, layers, filt, width, height, force, image_format
+):
+    key_parts = (srs, tuple(layers), filt, width, height, force)
+    for format_key in (image_format, mimetypes.get(image_format)):
+        key = key_parts + (format_key,)
+        if key in response_cache:
+            return response_cache[key]
+    return None
+
+
 def twms_main(data):
     """
     Do main TWMS work. 
@@ -219,19 +230,18 @@ def twms_main(data):
         y = int(data.get("y", 0))
         z = int(data.get("z", 1)) + 1
         if "cache_tile_responses" in dir(config) and not wkt and (len(gpx) == 0):
-            if (
+            response_cache = _response_cache_entry(
+                config.cache_tile_responses,
                 srs,
-                tuple(layer),
+                layer,
                 filt,
                 width,
                 height,
                 force,
                 format,
-            ) in config.cache_tile_responses:
-
-                resp_cache_path, resp_ext = config.cache_tile_responses[
-                    (srs, tuple(layer), filt, width, height, force, format)
-                ]
+            )
+            if response_cache:
+                resp_cache_path, resp_ext = response_cache
                 resp_cache_path = resp_cache_path + "/%s/%s/%s.%s" % (
                     z - 1,
                     x,

--- a/twms/twms.py
+++ b/twms/twms.py
@@ -187,8 +187,8 @@ def twms_main(data):
             if layer[0] in config.layers:
                 if (
                     config.layers[layer[0]]["proj"] == srs
-                    and width is 256
-                    and height is 256
+                    and width == 256
+                    and height == 256
                     and not filt
                     and not force
                     and not correctify.has_corrections(config.layers[layer[0]])

--- a/twms/twms.py
+++ b/twms/twms.py
@@ -102,6 +102,13 @@ def _layer_bounds(layer):
     )
 
 
+def _layer_extension(layer):
+    return layer.get(
+        "ext",
+        layer.get("mimetype", "image/jpeg").lower().replace("image/", ""),
+    ).lower().replace("jpeg", "jpg")
+
+
 def twms_main(data):
     """
     Do main TWMS work. 
@@ -273,7 +280,7 @@ def twms_main(data):
                         + config.layers[layer[0]]["prefix"]
                         + "/z%s/%s/x%s/%s/y%s." % (z, x // 1024, x, y // 1024, y)
                     )
-                    ext = config.layers[layer[0]]["ext"]
+                    ext = _layer_extension(config.layers[layer[0]])
                     adds = ["", "ups."]
                     for add in adds:
                         if os.path.exists(local + add + ext):
@@ -469,7 +476,7 @@ def tile_image(layer, z, x, y, start_time, again=False, trybetter=True, real=Fal
             + layer["prefix"]
             + "/z%s/%s/x%s/%s/y%s." % (z, x // 1024, x, y // 1024, y)
         )
-        ext = layer["ext"]
+        ext = _layer_extension(layer)
         if "cache_ttl" in layer:
             for ex in [ext, "dsc." + ext, "ups." + ext, "tne"]:
                 f = local + ex

--- a/twms/twms.py
+++ b/twms/twms.py
@@ -232,14 +232,14 @@ def twms_main(data):
                     local = (
                         config.tiles_cache
                         + config.layers[layer[0]]["prefix"]
-                        + "/z%s/%s/x%s/%s/y%s." % (z, x / 1024, x, y / 1024, y)
+                        + "/z%s/%s/x%s/%s/y%s." % (z, x // 1024, x, y // 1024, y)
                     )
                     ext = config.layers[layer[0]]["ext"]
                     adds = ["", "ups."]
                     for add in adds:
                         if os.path.exists(local + add + ext):
-                            tile_file = open(local + add + ext, "r")
-                            resp = tile_file.read()
+                            with open(local + add + ext, "rb") as tile_file:
+                                resp = tile_file.read()
                             return (OK, content_type, resp)
         req_bbox = projections.from4326(projections.bbox_by_tile(z, x, y, srs), srs)
 
@@ -428,7 +428,7 @@ def tile_image(layer, z, x, y, start_time, again=False, trybetter=True, real=Fal
         local = (
             config.tiles_cache
             + layer["prefix"]
-            + "/z%s/%s/x%s/%s/y%s." % (z, x / 1024, x, y / 1024, y)
+            + "/z%s/%s/x%s/%s/y%s." % (z, x // 1024, x, y // 1024, y)
         )
         ext = layer["ext"]
         if "cache_ttl" in layer:

--- a/twms/twms.py
+++ b/twms/twms.py
@@ -95,6 +95,13 @@ def _response_cache_entry(
     return None
 
 
+def _layer_bounds(layer):
+    return layer.get(
+        "data_bounding_box",
+        layer.get("bounds", layer.get("bbox", config.default_bbox)),
+    )
+
+
 def twms_main(data):
     """
     Do main TWMS work. 
@@ -447,7 +454,7 @@ def tile_image(layer, z, x, y, start_time, again=False, trybetter=True, real=Fal
         return None
     if not bbox.bbox_is_in(
         projections.bbox_by_tile(z, x, y, layer["proj"]),
-        layer.get("data_bounding_box", config.default_bbox),
+        _layer_bounds(layer),
         fully=False,
     ):
         return None

--- a/twms/twms.py
+++ b/twms/twms.py
@@ -7,8 +7,6 @@
 # and/or modify it under the terms specified in COPYING.
 
 import datetime
-import importlib.machinery
-import importlib.util
 import math
 import os
 import sys
@@ -16,34 +14,12 @@ import time
 import urllib
 from io import BytesIO
 
-# import config
 sys.path.append(os.path.join(os.path.dirname(__file__)))
 
-
-def load_config(path):
-    loader = importlib.machinery.SourceFileLoader("twms.config", path)
-    spec = importlib.util.spec_from_loader("twms.config", loader)
-    module = importlib.util.module_from_spec(spec)
-    sys.modules["twms.config"] = module
-    sys.modules["config"] = module
-    loader.exec_module(module)
-    return module
+from twms.config_loader import load_default_config
 
 
-config_path = "/etc/twms/twms.conf"
-if os.path.exists(config_path):
-    config = load_config(config_path)
-else:
-    try:
-        config_path = os.path.join(os.path.dirname(__file__), "twms.conf")
-        config = load_config(config_path)
-    except:
-        config_path = os.path.join(os.path.realpath(sys.path[0]), "twms.conf")
-        config = load_config(config_path)
-    sys.stderr.write(
-        "Configuration file not found, using defaults from %s\n" % config_path
-    )
-    sys.stderr.flush()
+config = load_default_config()
 
 import bbox
 import capabilities

--- a/twms/twms.py
+++ b/twms/twms.py
@@ -29,6 +29,7 @@ import fetchers
 import overview
 import projections
 import tilejson
+import wmts
 from bbox import expand_to_point, zoom_for_bbox
 from gpxparse import GPXParser
 from PIL import Image, ImageColor, ImageOps
@@ -107,6 +108,19 @@ def twms_main(data):
     req_type = data.get("request", "GetMap")
     version = data.get("version", "1.1.1")
     ref = data.get("ref", config.service_url)
+    if data.get("service", "").lower() == "wmts" and req_type.lower() == "getcapabilities":
+        return (OK, "text/xml", wmts.capabilities(config, ref))
+    if req_type.lower() == "getwmtscapabilities":
+        return (OK, "text/xml", wmts.capabilities(config, ref))
+    if data.get("service", "").lower() == "wmts" and req_type.lower() == "gettile":
+        if "layers" not in data and "layer" in data:
+            data["layers"] = data["layer"]
+        if "z" not in data and "tilematrix" in data:
+            data["z"] = data["tilematrix"]
+        if "x" not in data and "tilecol" in data:
+            data["x"] = data["tilecol"]
+        if "y" not in data and "tilerow" in data:
+            data["y"] = data["tilerow"]
     if req_type == "GetCapabilities":
         content_type, resp = capabilities.get(version, ref)
         return (OK, content_type, resp)

--- a/twms/twms.py
+++ b/twms/twms.py
@@ -67,6 +67,7 @@ def twms_main(data):
     data - dictionary of params. 
     returns (error_code, content_type, resp)
     """
+    data = dict((key.lower(), data[key]) for key in data)
     # import the filter here due to a circular dependency
     # TODO: break the loop
     import filter
@@ -75,7 +76,7 @@ def twms_main(data):
 
     content_type = "text/html"
     resp = ""
-    srs = data.get("srs", "EPSG:4326")
+    srs = data.get("crs", data.get("srs", "EPSG:4326"))
     gpx = data.get("gpx", "").split(",")
     if gpx == [""]:
         gpx = []
@@ -106,13 +107,14 @@ def twms_main(data):
             tracks.append(track)
 
     req_type = data.get("request", "GetMap")
+    req_type_lower = req_type.lower()
     version = data.get("version", "1.1.1")
     ref = data.get("ref", config.service_url)
-    if data.get("service", "").lower() == "wmts" and req_type.lower() == "getcapabilities":
+    if data.get("service", "").lower() == "wmts" and req_type_lower == "getcapabilities":
         return (OK, "text/xml", wmts.capabilities(config, ref))
-    if req_type.lower() == "getwmtscapabilities":
+    if req_type_lower == "getwmtscapabilities":
         return (OK, "text/xml", wmts.capabilities(config, ref))
-    if data.get("service", "").lower() == "wmts" and req_type.lower() == "gettile":
+    if data.get("service", "").lower() == "wmts" and req_type_lower == "gettile":
         if "layers" not in data and "layer" in data:
             data["layers"] = data["layer"]
         if "z" not in data and "tilematrix" in data:
@@ -121,10 +123,10 @@ def twms_main(data):
             data["x"] = data["tilecol"]
         if "y" not in data and "tilerow" in data:
             data["y"] = data["tilerow"]
-    if req_type == "GetCapabilities":
+    if req_type_lower == "getcapabilities":
         content_type, resp = capabilities.get(version, ref)
         return (OK, content_type, resp)
-    if req_type.lower() in ("gettilejson", "tilejson"):
+    if req_type_lower in ("gettilejson", "tilejson"):
         try:
             resp = tilejson.dumps(
                 config,
@@ -140,7 +142,7 @@ def twms_main(data):
     if ("layers" in data) and not layer[0]:
         layer = ["transparent"]
 
-    if req_type == "GetCorrections":
+    if req_type_lower == "getcorrections":
         points = data.get("points", data.get("POINTS", "")).split("=")
         resp = ""
         points = [a.split(",") for a in points]
@@ -178,12 +180,12 @@ def twms_main(data):
     width = 0
     height = 0
     resp_cache_path, resp_ext = "", ""
-    if req_type == "GetTile":
+    if req_type_lower == "gettile":
         width = 256
         height = 256
         height = int(data.get("height", height))
         width = int(data.get("width", width))
-        srs = data.get("srs", "EPSG:3857")
+        srs = data.get("crs", data.get("srs", "EPSG:3857"))
         x = int(data.get("x", 0))
         y = int(data.get("y", 0))
         z = int(data.get("z", 1)) + 1

--- a/twms/twms.py
+++ b/twms/twms.py
@@ -218,7 +218,8 @@ def twms_main(data):
                     resp_ext,
                 )
                 if os.path.exists(resp_cache_path):
-                    return (OK, content_type, open(resp_cache_path, "r").read())
+                    with open(resp_cache_path, "rb") as cached_response:
+                        return (OK, content_type, cached_response.read())
         if len(layer) == 1:
             if layer[0] in config.layers:
                 if (
@@ -391,9 +392,8 @@ def twms_main(data):
         except OSError:
             pass
         try:
-            a = open(resp_cache_path, "w")
-            a.write(resp)
-            a.close()
+            with open(resp_cache_path, "wb") as cached_response:
+                cached_response.write(resp)
         except (OSError, IOError):
             print(
                 "error saving response answer to file %s." % (resp_cache_path),

--- a/twms/version.py
+++ b/twms/version.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+
+__version__ = "0.07z"
+
+# Python packaging metadata must be PEP 440. Keep the public TWMS keyboard
+# version above; this adapter exists only for wheel/sdist tooling.
+__packaging_version__ = "0.7+z"

--- a/twms/wmts.py
+++ b/twms/wmts.py
@@ -21,10 +21,15 @@ def _tag(namespace, name):
 
 
 def _extension(layer):
-    return layer.get("ext", "jpg").lower().replace("jpeg", "jpg")
+    return layer.get(
+        "ext",
+        layer.get("mimetype", "image/jpeg").lower().replace("image/", ""),
+    ).lower().replace("jpeg", "jpg")
 
 
 def _mime_type(layer):
+    if "mimetype" in layer:
+        return layer["mimetype"]
     ext = _extension(layer)
     if ext == "jpg":
         return "image/jpeg"

--- a/twms/wmts.py
+++ b/twms/wmts.py
@@ -1,0 +1,195 @@
+# -*- coding: utf-8 -*-
+#    This file is part of twms.
+
+# This program is free software. It comes without any warranty, to
+# the extent permitted by applicable law. You can redistribute it
+# and/or modify it under the terms specified in COPYING.
+
+import xml.etree.ElementTree as ET
+
+import projections
+
+
+WMTS = "http://www.opengis.net/wmts/1.0"
+OWS = "http://www.opengis.net/ows/1.1"
+XLINK = "http://www.w3.org/1999/xlink"
+XSI = "http://www.w3.org/2001/XMLSchema-instance"
+
+
+def _tag(namespace, name):
+    return "{%s}%s" % (namespace, name)
+
+
+def _extension(layer):
+    return layer.get("ext", "jpg").lower().replace("jpeg", "jpg")
+
+
+def _mime_type(layer):
+    ext = _extension(layer)
+    if ext == "jpg":
+        return "image/jpeg"
+    return "image/%s" % ext
+
+
+def _layer_bounds(config, layer):
+    return layer.get(
+        "data_bounding_box",
+        layer.get("bbox", config.default_bbox),
+    )
+
+
+def _tile_url(ref, layer_name, layer):
+    return "%swmts/%s/{TileMatrix}/{TileCol}/{TileRow}.%s" % (
+        ref,
+        layer_name,
+        _extension(layer),
+    )
+
+
+def _supported_crs(proj):
+    epsg = proj.split(":")[-1]
+    if epsg.isdigit():
+        return "urn:ogc:def:crs:EPSG::%s" % epsg
+    return proj
+
+
+def _projected_bounds(proj):
+    bounds = projections.projs[projections.proj_alias.get(proj, proj)]["bounds"]
+    return projections.from4326(bounds, proj)
+
+
+def _scale_denominator(proj, z):
+    projected = _projected_bounds(proj)
+    matrix_width = 2 ** z
+    resolution = (projected[2] - projected[0]) / (256 * matrix_width)
+    return resolution / 0.00028
+
+
+def _max_zoom_for_proj(config, proj):
+    zooms = [
+        layer.get("max_zoom", config.default_max_zoom)
+        for layer in config.layers.values()
+        if layer.get("proj", "EPSG:3857") == proj
+    ]
+    return max(zooms or [config.default_max_zoom])
+
+
+def _add_operation(parent, name, href):
+    operation = ET.SubElement(parent, _tag(OWS, "Operation"), {"name": name})
+    dcp = ET.SubElement(operation, _tag(OWS, "DCP"))
+    http = ET.SubElement(dcp, _tag(OWS, "HTTP"))
+    ET.SubElement(
+        http,
+        _tag(OWS, "Get"),
+        {_tag(XLINK, "href"): href},
+    )
+
+
+def _add_layer(parent, config, layer_name, layer, ref):
+    layer_element = ET.SubElement(parent, _tag(WMTS, "Layer"))
+    ET.SubElement(layer_element, _tag(OWS, "Title")).text = layer["name"]
+    ET.SubElement(layer_element, _tag(OWS, "Identifier")).text = layer_name
+
+    wgs84_bounds = ET.SubElement(layer_element, _tag(OWS, "WGS84BoundingBox"))
+    bounds = _layer_bounds(config, layer)
+    ET.SubElement(wgs84_bounds, _tag(OWS, "LowerCorner")).text = "%s %s" % (
+        bounds[0],
+        bounds[1],
+    )
+    ET.SubElement(wgs84_bounds, _tag(OWS, "UpperCorner")).text = "%s %s" % (
+        bounds[2],
+        bounds[3],
+    )
+
+    style = ET.SubElement(layer_element, _tag(WMTS, "Style"), {"isDefault": "true"})
+    ET.SubElement(style, _tag(OWS, "Identifier")).text = "default"
+    ET.SubElement(layer_element, _tag(WMTS, "Format")).text = _mime_type(layer)
+
+    link = ET.SubElement(layer_element, _tag(WMTS, "TileMatrixSetLink"))
+    ET.SubElement(link, _tag(WMTS, "TileMatrixSet")).text = layer.get("proj", "EPSG:3857")
+    ET.SubElement(
+        layer_element,
+        _tag(WMTS, "ResourceURL"),
+        {
+            "format": _mime_type(layer),
+            "resourceType": "tile",
+            "template": _tile_url(ref, layer_name, layer),
+        },
+    )
+
+
+def _add_tile_matrix_set(parent, config, proj):
+    projected = _projected_bounds(proj)
+    tile_matrix_set = ET.SubElement(parent, _tag(WMTS, "TileMatrixSet"))
+    ET.SubElement(tile_matrix_set, _tag(OWS, "Identifier")).text = proj
+    ET.SubElement(tile_matrix_set, _tag(OWS, "SupportedCRS")).text = _supported_crs(proj)
+
+    for z in range(_max_zoom_for_proj(config, proj) + 1):
+        matrix_size = 2 ** z
+        tile_matrix = ET.SubElement(tile_matrix_set, _tag(WMTS, "TileMatrix"))
+        ET.SubElement(tile_matrix, _tag(OWS, "Identifier")).text = str(z)
+        ET.SubElement(tile_matrix, _tag(WMTS, "ScaleDenominator")).text = str(
+            _scale_denominator(proj, z)
+        )
+        ET.SubElement(tile_matrix, _tag(WMTS, "TopLeftCorner")).text = "%s %s" % (
+            projected[0],
+            projected[3],
+        )
+        ET.SubElement(tile_matrix, _tag(WMTS, "TileWidth")).text = "256"
+        ET.SubElement(tile_matrix, _tag(WMTS, "TileHeight")).text = "256"
+        ET.SubElement(tile_matrix, _tag(WMTS, "MatrixWidth")).text = str(matrix_size)
+        ET.SubElement(tile_matrix, _tag(WMTS, "MatrixHeight")).text = str(matrix_size)
+
+
+def capabilities(config, ref):
+    ET.register_namespace("", WMTS)
+    ET.register_namespace("ows", OWS)
+    ET.register_namespace("xlink", XLINK)
+    ET.register_namespace("xsi", XSI)
+
+    root = ET.Element(
+        _tag(WMTS, "Capabilities"),
+        {
+            "version": "1.0.0",
+            _tag(XSI, "schemaLocation"): (
+                "http://www.opengis.net/wmts/1.0 "
+                "http://schemas.opengis.net/wmts/1.0/wmtsGetCapabilities_response.xsd"
+            ),
+        },
+    )
+    service = ET.SubElement(root, _tag(OWS, "ServiceIdentification"))
+    ET.SubElement(service, _tag(OWS, "Title")).text = config.wms_name
+    ET.SubElement(service, _tag(OWS, "ServiceType")).text = "OGC WMTS"
+    ET.SubElement(service, _tag(OWS, "ServiceTypeVersion")).text = "1.0.0"
+
+    operations = ET.SubElement(root, _tag(OWS, "OperationsMetadata"))
+    _add_operation(
+        operations,
+        "GetCapabilities",
+        "%swmts/1.0.0/WMTSCapabilities.xml" % ref,
+    )
+    _add_operation(operations, "GetTile", ref)
+
+    contents = ET.SubElement(root, _tag(WMTS, "Contents"))
+    projections_in_use = set()
+    for layer_name in sorted(config.layers.keys()):
+        layer = config.layers[layer_name]
+        proj = layer.get("proj", "EPSG:3857")
+        if proj not in projections.projs:
+            continue
+        projections_in_use.add(proj)
+        _add_layer(contents, config, layer_name, layer, ref)
+
+    for proj in sorted(projections_in_use):
+        _add_tile_matrix_set(contents, config, proj)
+
+    ET.SubElement(
+        root,
+        _tag(WMTS, "ServiceMetadataURL"),
+        {_tag(XLINK, "href"): "%swmts/1.0.0/WMTSCapabilities.xml" % ref},
+    )
+
+    return '<?xml version="1.0" encoding="UTF-8"?>\n' + ET.tostring(
+        root,
+        encoding="unicode",
+    )

--- a/twms/wmts.py
+++ b/twms/wmts.py
@@ -34,7 +34,7 @@ def _mime_type(layer):
 def _layer_bounds(config, layer):
     return layer.get(
         "data_bounding_box",
-        layer.get("bbox", config.default_bbox),
+        layer.get("bounds", layer.get("bbox", config.default_bbox)),
     )
 
 


### PR DESCRIPTION
## Summary

This draft rebuilds the useful parts of Komzpa/twms#21 as a clean semantic stack on top of Komzpa/twms master. It intentionally keeps TWMS tiny and general-purpose: no broad service-specific defaults, no large framework rewrite, no license/author deletion, and no Java-factory-shaped architecture.

Current commits:

- `88cfbb9` bootstraps packaging and GitHub Actions CI.
- `1320671` adds legacy package smoke tests and compatibility shims.
- `47455de` clears Python 3 syntax warnings without changing behavior.
- `996ce0b` adds a no-network legacy `GetTile` smoke test.
- `60bd619` adds a tiny stdlib `ThreadingHTTPServer` entry point while keeping `web.py`/WSGI available as `twms-webpy`.
- `f121d79` exposes TileJSON-style tileset metadata.
- `1ddb2bb` exposes WMTS 1.0.0 capabilities plus REST and KVP tile access, with Radioxoma authorship preserved.
- `3989521` modernizes the filesystem tile cache with TTL, `.tne`, stale fallback, atomic replacement, and Radioxoma-style `dead_tile` dictionaries.
- `c7c3b49` modernizes projection fallback with pole-edge clamping and optional `pyproj.Transformer`.
- `317dc88` adds tiny WMS 1.3.0 and `CRS:84` support for QGIS-style clients without replacing WMS 1.1.1.
- `4aa6b65` rewrites README client/deployment docs for stdlib, `web.py`, QGIS, JOSM, WMTS, TileJSON, GetTile, shared caches, and optional dependencies.
- `daed6f6` adds a Windows executable artifact job for `twms.exe` and `twms-webpy.exe`.
- `35c847e` preserves filters, corrections, drawing, canvas, and reprojection surfaces with current Python/Pillow fixes.
- `c24f53d` validates downloaded image bytes before caching and converts mismatched tile responses to the configured layer extension.
- `237dac5` records HTTP 404 and configured `dead_tile.http_status` values as `.tne` cache misses.
- `2aa87ce` accepts readable named tile URL placeholders while preserving legacy `%s` templates.
- `2980eaa` generates JOSM maps-1.0 imagery XML.
- `041580c` fixes atomic WMS cache writes by passing the intended image format explicitly.
- `61df8a7` supports optional per-layer HTTP headers for tile and WMS upstreams.
- `a1339fa` enforces per-layer `min_zoom` while preserving existing exclusive `max_zoom`.
- `7852d8a` adds opt-in `cache_layout: "zxy"` while keeping TWMS' historical grouped cache layout by default.
- `98c39bd` accepts readable named WMS URL placeholders while preserving legacy base-URL query appending.
- `794940b` bounds upstream tile/WMS fetch waits with global/per-layer timeout config.
- `faadb4e` hardens stdlib REST routing and WMTS REST URLs with query strings.
- `2fe1b21` applies bounded upstream waits to the preserved legacy `WmsCanvas`.
- `ad5ead4` restores legacy `empty_color` overlay transparency and `empty_color_delta`.
- `637ef8b` keeps historical cache lookups and cached `GetTile` bytes binary-safe.
- `eb261e0` keeps legacy `cache_tile_responses` binary-safe.
- `a4e0d9e` adds optional transient upstream retries without retrying HTTP/TNE statuses.
- `618a447` makes the RAM tile cache least-recently-used and fixes its bound.
- `0dc7b06` accepts MIME format keys such as `image/png` in `cache_tile_responses`.
- `d99e15a` documents the cookie decision: per-layer headers yes, automatic browser cookie discovery no.
- `a85b8b4` keeps generated-artifact ignore hygiene without broad unrelated IDE/tooling ignores.
- `952f1ae` accepts readable layer `bounds` metadata aliases.
- `f168719` enriches JOSM imagery XML with bounds, overlay/default/georeference hints, attribution URLs, zoom limits, and no-tile checksums.
- `b29d80d` aligns the overview page with layer bounds aliases and provider URLs.
- `edabf43` ships optional Windows batch and Linux desktop-entry launcher templates as packaged contrib files.
- `b8b3d18` cancels stale CI runs for the same workflow event and branch.
- `a86e856` accepts layer `mimetype` metadata as a readable alias/source for tile extensions while preserving legacy `ext` configs.
- `f2522cc` supports `image/webp` as a normal WMS output format while reusing the existing Pillow format path.
- `d552b8a` supports optional `layer_defaults` in Python configs through a tiny dict wrapper rather than importing the fork config rewrite.
- `d0b1ed1` adds tiny stdlib route aliases for `/wms` tile/query URLs and `/josm/maps.xml` while keeping routing delegated to `twms_main`.
- `2cd346c` prints useful stdlib-server startup URLs and includes the TWMS version in the HTTP `Server` header without importing the fork logging rewrite.
- `fbf33d1` accepts readable string fetcher aliases such as `"tms"` and `"wms"` while resolving them back to the existing legacy fetcher functions.
- `7e4d2ed` makes the import smoke check shell-portable so the same GitHub Actions workflow passes under Bash on Linux and PowerShell on Windows.

## Branch behavior

The branch currently:

- adds GitHub Actions CI for Ubuntu and Windows on Python 3.11 and 3.13;
- adds a Windows executable artifact job for stdlib and preserved `web.py` entry points;
- modernizes packaging with `pyproject.toml`;
- preserves TWMS' public keyboard-style version as `0.07z`, while exposing PEP 440 metadata as `0.7+z`;
- replaces the removed Python 3.13 `imp` loader with `importlib`;
- keeps old package-style imports working without a large relative-import rewrite;
- keeps WMS 1.1.1, adds WMS 1.3.0/CRS:84, WMTS, TileJSON, JOSM imagery XML, overview metadata, and WebP WMS output;
- keeps `GetTile` because it is still useful for passing filters through tile URLs, including direct `/wms/<layer>/<z>/<x>/<y>` route aliases;
- keeps TWMS' built-in projection shortlist tiny, with optional `pyproj` for configured non-core projections;
- keeps historical cache layout by default, with optional z/x/y shared-cache layout;
- supports cache TTL, stale fallback, `.tne`, `dead_tile`, binary-safe response caches, layer headers, min zoom, timeouts, retries, and named upstream URL placeholders;
- accepts layer `mimetype` metadata as an alias/source for tile extensions while preserving existing `ext` configs;
- supports optional `layer_defaults` for shared layer metadata without merging defaults into every layer;
- accepts readable `fetch` aliases `"tms"` / `"tile"` and `"wms"` while preserving callable legacy fetchers;
- keeps `/josm/imagery.xml`, `/josm/maps.xml`, and `/maps.xml` as generated imagery-list aliases;
- prints stdlib-server startup URLs for overview, WMS, WMTS, and JOSM clients, and reports a versioned HTTP `Server` header;
- ships optional launcher templates for old Windows/JOSM proxy and Linux desktop/manual downstream deployments without installing desktop integration by default;
- preserves legacy filter, correction, WKT/GPX drawing, canvas, reprojection, tools, manpage, WSGI, and `web.py` deployment surfaces;
- credits Eugene Dvoretsky (Radioxoma) in `COPYING` and README for modernization work;
- keeps upstream Public Domain/ISC license text instead of taking the fork's license rewrite.

## Validation

Clean-venv validation passed through current head `7e4d2ed2bf7ed793d040335f0a2af672a7150154`:

- editable install in a clean venv
- `python -m compileall -q setup.py index.py tools twms tests`
- WSGI application import
- assertions that `twms.__version__ == "0.07z"` and installed package metadata is `0.7+z`
- `python -m unittest discover -s tests -v` (`75` tests, `1` optional `pyproj` skip)
- `python -m build`
- source distribution and wheel contents include `contrib/twms.bat` and `contrib/twms.desktop`
- `git diff --check`

The optional projection extra was also checked separately:

- `pip install -e '.[proj]'`
- `python -m unittest tests.test_legacy_smoke.LegacySmokeTest.test_optional_pyproj_projection_uses_modern_transformer -v`

The smoke suite covers WMS 1.1.1/1.3.0, CRS:84, GetTile, stdlib serving, stdlib startup banner, versioned HTTP `Server` header, TileJSON, WMTS capabilities/KVP/REST, JOSM imagery XML, overview HTML, cache TTL/TNE/stale/dead-tile behavior, binary cache reads/writes, layer headers, min/max zoom, zxy cache layout, named URL placeholders, upstream timeout/retry behavior, projection fallback, optional pyproj, legacy rendering helpers, layer bounds aliases, layer mimetype aliases, layer defaults, string fetcher aliases, WebP WMS output, stdlib WMS/JOSM route aliases, and Windows/package artifact contents.

GitHub Actions passed on current head `7e4d2ed2bf7ed793d040335f0a2af672a7150154`:

- push run: https://github.com/Komzpa/twms/actions/runs/30205132979
- pull request run: https://github.com/Komzpa/twms/actions/runs/30205134325

Both runs passed Ubuntu and Windows package smoke jobs for Python 3.11 and 3.13, plus the Windows executable artifact job that builds and uploads `twms.exe` and `twms-webpy.exe`.

## Selection notes

This branch deliberately rebuilds Komzpa/twms#21 as semantic pieces instead of merging the fork wholesale.

Taken, but reshaped to fit upstream TWMS:

- modern packaging, tests, GitHub Actions, and Windows executable artifacts;
- stdlib serving while preserving the existing `web.py`/WSGI deployment path;
- WMS 1.3.0, WMTS, TileJSON, JOSM imagery XML, and QGIS/JOSM documentation;
- cache TTL/TNE/stale-cache behavior, image validation, named URL templates, headers, min zoom, optional retries, and opt-in shared slippy-cache layout;
- projection modernization with a tiny built-in shortlist plus optional `pyproj` for non-core projections;
- readable metadata aliases such as `bounds` and `mimetype`;
- WebP output support as a tiny MIME/format-map extension;
- optional layer defaults as a small config-loader feature;
- readable string fetcher aliases as a config-loader adapter to the existing fetchers;
- tiny route aliases from the fork without importing the fork `api.py` split;
- stdlib startup URL hints and a versioned `Server` header without importing the fork logging/color-output rewrite;
- optional launcher templates as packaged contrib files.

Not taken from Komzpa/twms#21:

- the license rewrite and author/copyright removals;
- deletion of legacy filters, corrections, drawing, canvas, reprojection, tools, manpage, WSGI, or `web.py` deployment surfaces;
- the service-specific default provider config, DZZ/Firefox cookie auto-discovery, and browser-like global headers;
- the broad OOP fetcher/cache/config rewrite, including the thread-pool code that was described as async but still blocks on `submit(...).result()`;
- provider-specific dynamic Google tile URL discovery from JavaScript;
- colored logging, debug trace output, and global logging rewrites;
- JOSM remote-control links embedded in the overview HTML; generated maps-1.0 imagery XML and documented TMS/file-cache setup cover JOSM without making the overview page active;
- the broad black/pre-commit/mypy/docstring formatting pass;
- the public version jump to semver-style 2.x naming.

## Scope

Ready for review. The reciprocal Radioxoma branch update has been posted as https://github.com/radioxoma/twms/pull/1; that fork PR is expected to be a replace/rebase PR rather than a clean merge because the fork branch history diverged from upstream.

