### PR TITLE
Fix legacy issues and restore docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ twms loads Python configuration from:
 2. the packaged `twms/twms.conf`
 3. `twms.conf` in the current script directory
 
+The old Google Code wiki documentation is now kept in this repository under
+[`docs/`](docs/index.md), including an expanded configuration reference,
+installation notes, and filter documentation.
+
 Important settings:
 
 - `tiles_cache`: root directory for the filesystem tile cache

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,133 @@
+# Configuration reference
+
+TWMS loads Python configuration from:
+
+1. `/etc/twms/twms.conf`
+2. the packaged `twms/twms.conf`
+3. `twms.conf` next to the running script
+
+The packaged config is an example. Real deployments normally need local cache
+paths, layer definitions, and service metadata.
+
+## Common settings
+
+- `debug`: enable more verbose diagnostics.
+- `tiles_cache`: root directory for TWMS tile cache files.
+- `install_path`: directory for packaged assets such as dead-tile samples.
+- `gpx_cache`: cache directory for downloaded OSM GPX traces.
+- `deadline`: seconds during which remote downloads are allowed before TWMS
+  falls back to cached or lower-quality material.
+- `upstream_timeout`: HTTP timeout for upstream tile/WMS requests.
+- `upstream_retries` / `upstream_retry_delay`: retry budget for transient
+  upstream network errors.
+- `default_max_zoom`: default exclusive maximum zoom for layers that do not set
+  their own `max_zoom`.
+- `geometry_color`: default colors for WKT/GPX vector rendering.
+- `linestring_width`: default rendered width for WKT/GPX lines.
+- `default_layers`: comma-separated layer list used when a request omits
+  `layers`; an empty value shows the overview page.
+- `max_height` / `max_width`: maximum output image dimensions.
+- `output_quality`, `output_progressive`, `output_optimize`: output image
+  encoder options.
+- `default_background`: background color for empty space.
+- `default_vector_renderer`: `PIL` or `cairo`.
+- `default_format`: output MIME type such as `image/jpeg`.
+
+## Capabilities metadata
+
+- `service_url`: public base URL used in generated WMS/WMTS/JOSM metadata.
+- `wms_name`: service title.
+- `default_bbox`: advertised lon/lat bounds.
+- `contact_person`: metadata with `mail`, `real_name`, and `organization`.
+
+## Layers
+
+Each entry in `layers` describes one layer:
+
+```python
+layers = {
+    "osm": {
+        "name": "OpenStreetMap mapnik",
+        "prefix": "osm",
+        "ext": "png",
+        "proj": "EPSG:3857",
+        "fetch": "tms",
+        "remote_url": "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
+        "transform_tile_number": lambda z, x, y: (z - 1, x, y),
+        "scalable": False,
+        "cache_ttl": 864000,
+    },
+}
+```
+
+Common layer keys:
+
+- `name`: human-readable layer name.
+- `prefix`: cache subdirectory.
+- `ext` or `mimetype`: tile image type. `ext: "png"` and
+  `mimetype: "image/png"` are equivalent after config normalization.
+- `scalable`: allow TWMS to synthesize a lower zoom tile from higher zoom tiles.
+- `proj`: tile pyramid projection, commonly `EPSG:3857`, `EPSG:3395`, or
+  `EPSG:4326`.
+- `min_zoom` / `max_zoom`: layer zoom bounds. `max_zoom` is historically
+  exclusive.
+- `empty_color` / `empty_color_delta`: color treated as transparent when an
+  overlay layer is composited.
+- `cache_ttl`: seconds during which cached tiles are fresh.
+- `cached`: set to `False` for local or dynamic upstreams that should not be
+  written into TWMS' tile cache.
+- `cache_layout`: defaults to TWMS' historical grouped layout; `zxy`, `slippy`,
+  `mobac`, or `tms` use `<tiles_cache>/<prefix>/<z>/<x>/<y>.<ext>`.
+- `data_bounding_box`, `bounds`, or `bbox`: lon/lat layer bounds.
+- `headers`: per-layer HTTP headers for upstream requests.
+- `timeout`, `upstream_retries`, `upstream_retry_delay`: per-layer upstream
+  request overrides.
+- `layer_defaults`: optional top-level dictionary merged into every layer by
+  the config loader.
+
+## Fetchers
+
+`fetch` may be a legacy callable or one of the readable aliases:
+
+- `"tms"` / `"tile"` for tile URL sources.
+- `"wms"` for WMS upstream sources.
+
+Tile layers use:
+
+- `remote_url`: legacy `%s` templates or readable placeholders such as `{z}`,
+  `{x}`, `{y}`, `{-y}`, and `{q}`.
+- `transform_tile_number`: optional function called as `(z, x, y)`.
+- `dead_tile`: legacy file path or a dictionary with `size`, `md5`, and optional
+  `http_status` for sparse datasets.
+
+WMS upstream layers use:
+
+- `remote_url`: a base GetMap URL. Legacy configs append `bbox`, `width`,
+  `height`, and `srs`; readable templates may include `{bbox}`, `{width}`,
+  `{height}`, and `{proj}`.
+- `wms_proj`: projection requested from the upstream WMS if it differs from the
+  layer projection.
+
+## Response cache
+
+`cache_tile_responses` maps direct `GetTile` responses to an existing
+slippy-style cache:
+
+```python
+cache_tile_responses = {
+    ("EPSG:3857", ("base",), (), 256, 256, (), "PNG"): (
+        "/disk/base3857/",
+        "png",
+    ),
+}
+```
+
+The key is:
+
+```text
+(projection, layers, filters, width, height, force, format)
+```
+
+Use empty tuples `()` for no filters and no force options. The canonical format
+value is Pillow's format name (`"PNG"`, `"JPEG"`), although current TWMS also
+accepts MIME keys such as `"image/png"` for compatibility with older examples.

--- a/docs/filters.md
+++ b/docs/filters.md
@@ -1,0 +1,28 @@
+# Filters
+
+TWMS lets clients post-process rendered images with the `filter`/`filt`
+request parameter. Filters can be stacked and repeated:
+
+```text
+filter=median,edge,brightness:1.5
+```
+
+Built-in filters:
+
+- `bw`: convert to grayscale.
+- `contour`: render colored contours, useful for printing.
+- `median`: median filter, useful before other image processing.
+- `blur`: blur the image.
+- `edge`: detect and sharpen edges. This can help with compressed aerial
+  imagery, especially with `median`.
+- `brightness:x`: adjust brightness.
+- `contrast:x`: adjust contrast.
+- `sharpness:x`: adjust sharpness.
+- `swaprb`: swap red and blue channels for sources with channel-order issues.
+
+For tile clients that cannot send arbitrary WMS parameters, keep using the
+legacy `GetTile` endpoint so the filter list can live in the tile URL:
+
+```text
+http://127.0.0.1:8080/?request=GetTile&layers=osm&z={z}&x={x}&y={y}&format=png&filter=median,edge
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,17 @@
+# TWMS documentation
+
+These pages restore the old Google Code wiki documentation into the main
+repository branch and update it for the current Python 3 package.
+
+- [Installing and running](installing.md)
+- [Configuration reference](configuration.md)
+- [Filters](filters.md)
+
+TWMS is a tiny WMS server and tile proxy. It primarily serves tile pyramids to
+WMS-enabled GIS clients, while also exposing direct tile URLs, WMTS metadata,
+TileJSON, and JOSM imagery XML.
+
+The old wiki lived outside the main source tree, which made it easy for package
+users and downstream proxy builds to miss. Keeping these docs in `master` means
+the source distribution, GitHub checkout, and Debian packaging all carry the
+same operational notes.

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -1,0 +1,103 @@
+# Installing and running TWMS
+
+## Dependencies
+
+The base package is intentionally small:
+
+- Python 3.11 or newer
+- Pillow
+- `web.py` for the preserved legacy WSGI/standalone entry point
+
+Optional extras:
+
+```sh
+python -m pip install -e '.[proj]'
+python -m pip install -e '.[cairo]'
+```
+
+- `twms[proj]` enables pyproj-backed transformations for configured
+  non-core projections.
+- `twms[cairo]` enables Cairo-backed vector rendering for deployments that used
+  the older Cairo/Pango rendering path.
+
+## From a checkout
+
+```sh
+python -m pip install -e .
+twms 8080
+```
+
+The default server uses the Python standard library and listens on
+`http://127.0.0.1:8080/`.
+
+The legacy `web.py` server remains available:
+
+```sh
+twms-webpy
+```
+
+That path is kept for old WSGI setups and small Windows/JOSM proxy bundles that
+depended on `web.py`.
+
+## Debian
+
+TWMS has historically been packaged for Debian. If your distribution carries the
+package, prefer the package manager and then adjust `/etc/twms/twms.conf`:
+
+```sh
+sudo apt install twms
+```
+
+Older Debian packages used `/etc/default/twms` with `RUN="yes"` for service
+startup. Check the packaging shipped by your distribution, because service
+management may differ between releases.
+
+## WSGI
+
+The WSGI application is still importable as `twms.daemon.application`.
+
+A minimal mod_wsgi deployment looks like:
+
+```apache
+WSGIDaemonProcess twms user=www-data group=www-data
+WSGIProcessGroup twms
+WSGIScriptAlias / /path/to/twms/index.py
+
+<Directory /path/to/twms>
+    Require all granted
+</Directory>
+```
+
+The old Google Code wiki also documented `mod_python`; that stack is obsolete
+and is not recommended for new deployments.
+
+## Windows and JOSM proxy use
+
+GitHub Actions builds Windows executable artifacts from the current branch:
+
+- `twms.exe` for the stdlib server
+- `twms-webpy.exe` for the preserved `web.py` entry point
+
+Optional launcher templates are packaged under `share/twms/contrib/`:
+
+- `twms.bat`
+- `twms.desktop`
+
+For JOSM, run TWMS locally and add a TMS imagery entry such as:
+
+```text
+tms:http://127.0.0.1:8080/osm/{zoom}/{x}/{y}.png
+```
+
+When a layer needs TWMS-specific parameters such as filters, use the legacy
+`GetTile` style:
+
+```text
+tms:http://127.0.0.1:8080/?request=GetTile&layers=osm&z={zoom}&x={x}&y={y}&format=png
+```
+
+TWMS also publishes a JOSM imagery list:
+
+```text
+http://127.0.0.1:8080/josm/imagery.xml
+```

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
     data_files = [
         (os.path.join('share', 'doc', __name__), ['COPYING']),
         (os.path.join('share', 'doc', __name__), glob('*.md')),
+        (os.path.join('share', 'doc', __name__, 'docs'), glob(os.path.join('docs', '*.md'))),
         (os.path.join('share', __name__), glob('*.jpg')),
         (os.path.join('share', __name__, 'tools'), glob(os.path.join('tools', '*.py'))),
         (os.path.join('share', __name__, 'contrib'), glob(os.path.join('contrib', '*'))),

--- a/tests/test_legacy_smoke.py
+++ b/tests/test_legacy_smoke.py
@@ -1184,6 +1184,44 @@ class LegacySmokeTest(unittest.TestCase):
                 else:
                     del twms.twms.config.cache_tile_responses
 
+    def test_filter_alias_matches_response_cache_keys(self):
+        with tempfile.TemporaryDirectory() as cache_root:
+            old_cache = getattr(twms.twms.config, "cache_tile_responses", None)
+            had_cache = hasattr(twms.twms.config, "cache_tile_responses")
+            twms.twms.config.cache_tile_responses = {
+                ("EPSG:3857", ("transparent",), ("bw",), 256, 256, (), "PNG"): (
+                    cache_root,
+                    "png",
+                ),
+            }
+            try:
+                path = os.path.join(cache_root, "2", "3", "4.png")
+                os.makedirs(os.path.dirname(path))
+                expected = self.image_bytes((82, 92, 102, 255))
+                with open(path, "wb") as cached_tile:
+                    cached_tile.write(expected)
+
+                status, content_type, body = twms.twms.twms_main(
+                    {
+                        "request": "GetTile",
+                        "layers": "transparent",
+                        "format": "image/png",
+                        "z": "2",
+                        "x": "3",
+                        "y": "4",
+                        "filter": "bw",
+                    }
+                )
+
+                self.assertEqual(status, 200)
+                self.assertEqual(content_type, "image/png")
+                self.assertEqual(body, expected)
+            finally:
+                if had_cache:
+                    twms.twms.config.cache_tile_responses = old_cache
+                else:
+                    del twms.twms.config.cache_tile_responses
+
     def test_legacy_response_cache_writes_binary_tile(self):
         with tempfile.TemporaryDirectory() as cache_root:
             old_cache = getattr(twms.twms.config, "cache_tile_responses", None)

--- a/tests/test_legacy_smoke.py
+++ b/tests/test_legacy_smoke.py
@@ -39,6 +39,20 @@ class LegacySmokeTest(unittest.TestCase):
         image.save(buffer, image_format)
         return buffer.getvalue()
 
+    def rendered_point_centroid(self, body):
+        image = Image.open(BytesIO(body)).convert("RGBA")
+        pixels = []
+        for y in range(image.height):
+            for x in range(image.width):
+                red, green, blue, alpha = image.getpixel((x, y))
+                if alpha and green > red and green > blue:
+                    pixels.append((x, y))
+        self.assertTrue(pixels, "expected a visible WKT point")
+        return (
+            sum(x for x, _ in pixels) / len(pixels),
+            sum(y for _, y in pixels) / len(pixels),
+        )
+
     def cache_path(self, cache_root, layer, z, x, y):
         return os.path.join(
             cache_root,
@@ -381,6 +395,47 @@ class LegacySmokeTest(unittest.TestCase):
                 any(image.getchannel("A").tobytes()),
                 "WKT overlay should draw visible pixels",
             )
+
+    def test_wkt_point_position_follows_request_bbox(self):
+        examples = [
+            ("-83,-41.8,67,68.8", (396, 140)),
+            ("-83,11.8,67,68.8", (396, 272)),
+        ]
+        for bbox, expected in examples:
+            with self.subTest(bbox=bbox):
+                status, content_type, body = twms.twms.twms_main(
+                    {
+                        "request": "GetMap",
+                        "layers": "transparent",
+                        "format": "image/png",
+                        "width": "800",
+                        "height": "600",
+                        "bbox": bbox,
+                        "wkt": "POINT(-8.55 42.85)",
+                    }
+                )
+
+                self.assertEqual(status, 200)
+                self.assertEqual(content_type, "image/png")
+                centroid = self.rendered_point_centroid(body)
+                self.assertAlmostEqual(centroid[0], expected[0], delta=1)
+                self.assertAlmostEqual(centroid[1], expected[1], delta=1)
+
+    def test_noresize_without_width_or_height_uses_tile_size(self):
+        status, content_type, body = twms.twms.twms_main(
+            {
+                "request": "GetMap",
+                "layers": "transparent",
+                "format": "image/png",
+                "bbox": "-1,-1,1,1",
+                "force": "noresize",
+            }
+        )
+
+        self.assertEqual(status, 200)
+        self.assertEqual(content_type, "image/png")
+        with Image.open(BytesIO(body)) as image:
+            self.assertEqual(image.size, (256, 256))
 
     def test_legacy_canvas_blank_tile_smoke(self):
         canvas = twms.canvas.WmsCanvas(tile_size=(32, 32))
@@ -1090,6 +1145,45 @@ class LegacySmokeTest(unittest.TestCase):
                 else:
                     del twms.twms.config.cache_tile_responses
 
+    def test_empty_filter_and_force_match_response_cache_keys(self):
+        with tempfile.TemporaryDirectory() as cache_root:
+            old_cache = getattr(twms.twms.config, "cache_tile_responses", None)
+            had_cache = hasattr(twms.twms.config, "cache_tile_responses")
+            twms.twms.config.cache_tile_responses = {
+                ("EPSG:3857", ("transparent",), (), 256, 256, (), "PNG"): (
+                    cache_root,
+                    "png",
+                ),
+            }
+            try:
+                path = os.path.join(cache_root, "2", "3", "4.png")
+                os.makedirs(os.path.dirname(path))
+                expected = self.image_bytes((80, 90, 100, 255))
+                with open(path, "wb") as cached_tile:
+                    cached_tile.write(expected)
+
+                status, content_type, body = twms.twms.twms_main(
+                    {
+                        "request": "GetTile",
+                        "layers": "transparent",
+                        "format": "image/png",
+                        "z": "2",
+                        "x": "3",
+                        "y": "4",
+                        "filter": "",
+                        "force": "",
+                    }
+                )
+
+                self.assertEqual(status, 200)
+                self.assertEqual(content_type, "image/png")
+                self.assertEqual(body, expected)
+            finally:
+                if had_cache:
+                    twms.twms.config.cache_tile_responses = old_cache
+                else:
+                    del twms.twms.config.cache_tile_responses
+
     def test_legacy_response_cache_writes_binary_tile(self):
         with tempfile.TemporaryDirectory() as cache_root:
             old_cache = getattr(twms.twms.config, "cache_tile_responses", None)
@@ -1395,6 +1489,49 @@ class LegacySmokeTest(unittest.TestCase):
                     self.assertEqual(cached_image.format, "PNG")
             finally:
                 twms.fetchers.config.tiles_cache = old_cache
+
+    def test_direct_gettile_first_fetch_returns_cached_upstream_bytes(self):
+        with tempfile.TemporaryDirectory() as cache_root:
+            old_twms_cache = twms.twms.config.tiles_cache
+            old_fetchers_cache = twms.fetchers.config.tiles_cache
+            old_layers = twms.twms.config.layers
+            twms.twms.config.tiles_cache = cache_root + os.sep
+            twms.fetchers.config.tiles_cache = cache_root + os.sep
+            layer = {
+                "prefix": "raw-first-fetch",
+                "proj": "EPSG:3857",
+                "ext": "png",
+                "scalable": False,
+                "fetch": twms.fetchers.Tile,
+                "remote_url": "http://example.test/%s/%s/%s.png",
+                "transform_tile_number": lambda z, x, y: (z - 1, x, y),
+            }
+            twms.twms.config.layers = {"raw-first-fetch": layer}
+            upstream_bytes = self.image_bytes((10, 20, 30, 255)) + b"raw-marker"
+            try:
+                path = self.cache_path(cache_root, layer, 3, 3, 3)
+                with mock.patch("twms.fetchers.urlopen") as urlopen:
+                    urlopen.return_value.read.return_value = upstream_bytes
+                    status, content_type, body = twms.twms.twms_main(
+                        {
+                            "request": "GetTile",
+                            "layers": "raw-first-fetch",
+                            "format": "image/png",
+                            "z": "2",
+                            "x": "3",
+                            "y": "3",
+                        }
+                    )
+
+                self.assertEqual(status, 200)
+                self.assertEqual(content_type, "image/png")
+                self.assertEqual(body, upstream_bytes)
+                with open(path, "rb") as cached_tile:
+                    self.assertEqual(cached_tile.read(), upstream_bytes)
+            finally:
+                twms.twms.config.tiles_cache = old_twms_cache
+                twms.fetchers.config.tiles_cache = old_fetchers_cache
+                twms.twms.config.layers = old_layers
 
     def test_tile_cache_accepts_mimetype_only_layer(self):
         with tempfile.TemporaryDirectory() as cache_root:

--- a/twms/twms.conf
+++ b/twms/twms.conf
@@ -50,8 +50,8 @@ contact_person = {
 
 cache_tile_responses = {
   # (projection, layers, filters, width, height, force, format): (path, ext)
-  ("EPSG:3857", ("base",), (), 256, 256, (), "image/jpeg"): ("/disk/base3857/", "jpg"),
-  ("EPSG:3857", ("base",), (), 256, 256, (), "image/png"): ("/disk/base3857/", "png"),
+  ("EPSG:3857", ("base",), (), 256, 256, (), "JPEG"): ("/disk/base3857/", "jpg"),
+  ("EPSG:3857", ("base",), (), 256, 256, (), "PNG"): ("/disk/base3857/", "png"),
   }
 
 

--- a/twms/twms.py
+++ b/twms/twms.py
@@ -235,7 +235,7 @@ def twms_main(data):
         force = force.split(",")
     force = tuple(force)
 
-    filt = data.get("filt", "")
+    filt = data.get("filt", data.get("filter", ""))
     if filt != "":
         filt = filt.split(",")
     filt = tuple(filt)

--- a/twms/twms.py
+++ b/twms/twms.py
@@ -110,6 +110,26 @@ def _layer_extension(layer):
     ).lower().replace("jpeg", "jpg")
 
 
+def _tile_cache_stem(layer, z, x, y):
+    cache_prefix = config.tiles_cache + layer["prefix"]
+    if layer.get("cache_layout") in ("zxy", "slippy", "mobac", "tms"):
+        return cache_prefix + "/%s/%s/%s." % (z, x, y)
+    return (
+        cache_prefix + "/z%s/%s/x%s/%s/y%s." % (z, x // 1024, x, y // 1024, y)
+    )
+
+
+def _cached_tile_bytes(layer, z, x, y):
+    stem = _tile_cache_stem(layer, z, x, y)
+    ext = _layer_extension(layer)
+    for add in ("", "ups."):
+        path = stem + add + ext
+        if os.path.exists(path):
+            with open(path, "rb") as tile_file:
+                return tile_file.read()
+    return None
+
+
 def twms_main(data):
     """
     Do main TWMS work. 
@@ -268,26 +288,23 @@ def twms_main(data):
                         return (OK, content_type, cached_response.read())
         if len(layer) == 1:
             if layer[0] in config.layers:
+                direct_layer = config.layers[layer[0]]
                 if (
-                    config.layers[layer[0]]["proj"] == srs
+                    direct_layer["proj"] == srs
                     and width == 256
                     and height == 256
                     and not filt
                     and not force
-                    and not correctify.has_corrections(config.layers[layer[0]])
+                    and direct_layer.get("cached", True)
+                    and not correctify.has_corrections(direct_layer)
                 ):
-                    local = (
-                        config.tiles_cache
-                        + config.layers[layer[0]]["prefix"]
-                        + "/z%s/%s/x%s/%s/y%s." % (z, x // 1024, x, y // 1024, y)
-                    )
-                    ext = _layer_extension(config.layers[layer[0]])
-                    adds = ["", "ups."]
-                    for add in adds:
-                        if os.path.exists(local + add + ext):
-                            with open(local + add + ext, "rb") as tile_file:
-                                resp = tile_file.read()
-                            return (OK, content_type, resp)
+                    cached_tile = _cached_tile_bytes(direct_layer, z, x, y)
+                    if cached_tile is not None:
+                        return (OK, content_type, cached_tile)
+                    tile_image(direct_layer, z, x, y, start_time, real=False)
+                    cached_tile = _cached_tile_bytes(direct_layer, z, x, y)
+                    if cached_tile is not None:
+                        return (OK, content_type, cached_tile)
         req_bbox = projections.from4326(projections.bbox_by_tile(z, x, y, srs), srs)
 
     if data.get("bbox", None):
@@ -305,7 +322,11 @@ def twms_main(data):
     width = min(width, config.max_width)
     height = min(height, config.max_height)
     if (width == 0) and (height == 0):
-        width = 350
+        if "noresize" in force:
+            width = 256
+            height = 256
+        else:
+            width = 350
 
     # layer = layer.split(",")
 
@@ -666,7 +687,9 @@ def getimg(bbox, request_proj, size, layer, start_time, force):
 
     # TODO: Here's a room for improvement. we could drop this crop in case user doesn't need it.
     out = out.crop(bbox_im)
-    if "noresize" not in force:
+    if "noresize" in force and (H == 0 or W == 0):
+        W, H = out.size
+    elif "noresize" not in force:
         if (H == W) and (H == 0):
             W, H = out.size
         if H == 0:


### PR DESCRIPTION
## Summary
- fix the remaining legacy issue regressions: WKT point positioning coverage, force=noresize without explicit width/height, response-cache config matching, direct GetTile first-fetch raw tile responses, and the documented filter= alias
- restore the old Google Code wiki material into maintained docs/ pages and package those docs in sdist and wheel artifacts
- keep the tiny/general TWMS shape: no framework expansion, optional extras stay optional, version remains 0.7+z/0.07z style

Closes #3.
Closes #10.
Closes #11.
Closes #13.

## Validation
- python -m compileall -q setup.py index.py tools twms tests
- python -m unittest discover -s tests -v (80 tests OK, 1 skipped: pyproj extra is not installed)
- python -m build
- build artifact readback: docs/*.md are included in the sdist and under share/doc/twms/docs in the wheel

## Notes
The build still emits the existing setuptools license-classifier deprecation warning; this PR leaves that unrelated packaging cleanup alone.