### PR TITLE
Fix reviewed legacy TWMS paths

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include tests/*.py

--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ Layer dictionaries usually define:
   override for temporary network failures. HTTP errors such as 404 are still
   handled by the cache/TNE rules instead of being retried as generic transport
   failures.
-- `min_zoom` / `max_zoom`: optional zoom limits
+- `min_zoom` / `max_zoom`: optional zoom limits; `max_zoom` is TWMS'
+  historical exclusive bound
 - `cache_ttl`: optional fresh-cache lifetime in seconds
 - `cache_layout`: optional cache path layout; the default is TWMS'
   historical grouped layout, while `zxy` stores slippy/MOBAC-style

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -70,7 +70,8 @@ Common layer keys:
 - `proj`: tile pyramid projection, commonly `EPSG:3857`, `EPSG:3395`, or
   `EPSG:4326`.
 - `min_zoom` / `max_zoom`: layer zoom bounds. `max_zoom` is historically
-  exclusive.
+  exclusive. TileJSON output converts it to the inclusive `maxzoom` value that
+  TileJSON clients expect.
 - `empty_color` / `empty_color_delta`: color treated as transparent when an
   overlay layer is composited.
 - `cache_ttl`: seconds during which cached tiles are fresh.

--- a/index.py
+++ b/index.py
@@ -10,9 +10,7 @@ from twms import twms
 
 if __name__ != "__main__":
     try:
-        import datetime
-
-        from mod_python import apache, util
+        from mod_python import util
     except ImportError:
         pass
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 import platform
 from glob import glob as abs_glob
 
-from setuptools import find_packages, setup
+from setuptools import setup
 
 
 __platform__ = platform.system()

--- a/tests/bench_projections.py
+++ b/tests/bench_projections.py
@@ -1,0 +1,110 @@
+"""Manual projection micro-benchmarks.
+
+Run with:
+
+    python tests/bench_projections.py
+
+This intentionally is not named ``test_*.py`` so normal unittest discovery stays
+fast and deterministic.
+"""
+
+import time
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from twms import projections
+
+
+ITERATIONS = 100_000
+MINSK_LON_LAT = (27.6, 53.2)
+MINSK_3857 = (3072417.9458943508, 7020078.5326420991)
+MINSK_3395 = (3072417.9458943508, 6985840.123947986)
+
+
+def timed(label, func):
+    start = time.perf_counter()
+    value = None
+    for _ in range(ITERATIONS):
+        value = func()
+    elapsed = time.perf_counter() - start
+    print("%-28s %.3fs %r" % (label, elapsed, value))
+
+
+def main():
+    pr_4326 = projections.projs["EPSG:4326"]["proj"]
+    pr_3857 = projections.projs["EPSG:3857"]["proj"]
+    pr_3395 = projections.projs["EPSG:3395"]["proj"]
+    has_pyproj = hasattr(projections.pyproj, "Transformer")
+    transform_3857_to_4326 = projections._pyproj_transformer(pr_3857, pr_4326)
+    transform_3395_to_4326 = projections._pyproj_transformer(pr_3395, pr_4326)
+    transform_4326_to_3857 = projections._pyproj_transformer(pr_4326, pr_3857)
+    transform_4326_to_3395 = projections._pyproj_transformer(pr_4326, pr_3395)
+
+    timed(
+        "pure 3857 -> 4326",
+        lambda: projections._c3857t4326(None, None, MINSK_3857[0], MINSK_3857[1]),
+    )
+    timed(
+        "wrapped 3857 -> 4326",
+        lambda: projections.to4326(MINSK_3857, "EPSG:3857"),
+    )
+    if has_pyproj:
+        timed(
+            "pyproj helper 3857 -> 4326",
+            lambda: transform_3857_to_4326(
+                pr_3857, pr_4326, MINSK_3857[0], MINSK_3857[1]
+            ),
+        )
+
+    timed(
+        "pure 3395 -> 4326",
+        lambda: projections._c3395t4326(None, None, MINSK_3395[0], MINSK_3395[1]),
+    )
+    timed(
+        "wrapped 3395 -> 4326",
+        lambda: projections.to4326(MINSK_3395, "EPSG:3395"),
+    )
+    if has_pyproj:
+        timed(
+            "pyproj helper 3395 -> 4326",
+            lambda: transform_3395_to_4326(
+                pr_3395, pr_4326, MINSK_3395[0], MINSK_3395[1]
+            ),
+        )
+
+    timed(
+        "pure 4326 -> 3857",
+        lambda: projections._c4326t3857(None, None, MINSK_LON_LAT[0], MINSK_LON_LAT[1]),
+    )
+    timed(
+        "wrapped 4326 -> 3857",
+        lambda: projections.from4326(MINSK_LON_LAT, "EPSG:3857"),
+    )
+    if has_pyproj:
+        timed(
+            "pyproj helper 4326 -> 3857",
+            lambda: transform_4326_to_3857(
+                pr_4326, pr_3857, MINSK_LON_LAT[0], MINSK_LON_LAT[1]
+            ),
+        )
+
+    timed(
+        "pure 4326 -> 3395",
+        lambda: projections._c4326t3395(None, None, MINSK_LON_LAT[0], MINSK_LON_LAT[1]),
+    )
+    timed(
+        "wrapped 4326 -> 3395",
+        lambda: projections.from4326(MINSK_LON_LAT, "EPSG:3395"),
+    )
+    if has_pyproj:
+        timed(
+            "pyproj helper 4326 -> 3395",
+            lambda: transform_4326_to_3395(
+                pr_4326, pr_3395, MINSK_LON_LAT[0], MINSK_LON_LAT[1]
+            ),
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_legacy_smoke.py
+++ b/tests/test_legacy_smoke.py
@@ -1,12 +1,13 @@
 import datetime
 import importlib
 import importlib.metadata
+import contextlib
 import hashlib
 import json
 import math
 import os
 from collections import OrderedDict
-from io import BytesIO
+from io import BytesIO, StringIO
 import tempfile
 import threading
 import unittest
@@ -22,9 +23,11 @@ from PIL import Image
 import twms
 import twms.canvas
 import twms.config_loader
+import twms.correctify
 import twms.daemon
 import twms.fetchers
 import twms.filter
+import twms.gpxparse
 import twms.projections
 import twms.server
 import twms.twms
@@ -367,12 +370,108 @@ class LegacySmokeTest(unittest.TestCase):
         self.assertEqual(content_type, "text/plain")
         self.assertEqual(body, "27.6,53.2;\n")
 
+    def test_legacy_gpx_track_points_keep_parse_order_on_python3(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".gpx", delete=False) as gpx_file:
+            gpx_path = gpx_file.name
+            gpx_file.write(
+                """<?xml version="1.0"?>
+                <gpx version="1.1" creator="twms-test">
+                  <trk><trkseg>
+                    <trkpt lat="53.1" lon="27.1"><time>2026-01-01T00:00:00Z</time></trkpt>
+                    <trkpt lat="53.2" lon="27.2"><time>2026-01-01T00:01:00Z</time></trkpt>
+                  </trkseg></trk>
+                </gpx>
+                """
+            )
+        try:
+            track = twms.gpxparse.GPXParser(gpx_path)
+        finally:
+            os.unlink(gpx_path)
+
+        self.assertEqual(track.bbox, (27.1, 53.1, 27.2, 53.2))
+        self.assertEqual(track.getTrack(0), [(27.1, 53.1), (27.2, 53.2)])
+
+    def test_legacy_gpx_trace_download_uses_python3_urlretrieve(self):
+        gpx_body = b"""<?xml version="1.0"?>
+        <gpx version="1.1" creator="twms-test">
+          <trk><trkseg>
+            <trkpt lat="53.1" lon="27.1"><time>2026-01-01T00:00:00Z</time></trkpt>
+            <trkpt lat="53.2" lon="27.2"><time>2026-01-01T00:01:00Z</time></trkpt>
+          </trkseg></trk>
+        </gpx>
+        """
+
+        def write_gpx(url, filename):
+            self.assertEqual(url, "http://www.openstreetmap.org/trace/123/data")
+            with open(filename, "wb") as trace_file:
+                trace_file.write(gpx_body)
+
+        with tempfile.TemporaryDirectory() as cache_root:
+            old_cache = twms.twms.config.gpx_cache
+            twms.twms.config.gpx_cache = cache_root + os.sep
+            try:
+                with mock.patch("twms.twms.urlretrieve", side_effect=write_gpx):
+                    status, content_type, body = twms.twms.twms_main(
+                        {
+                            "request": "GetMap",
+                            "layers": "transparent",
+                            "format": "image/png",
+                            "width": "16",
+                            "height": "16",
+                            "gpx": "123",
+                        }
+                    )
+
+                self.assertEqual(status, 200)
+                self.assertEqual(content_type, "image/png")
+                self.assertIsInstance(body, bytes)
+                self.assertTrue(os.path.exists(os.path.join(cache_root, "123.gpx")))
+            finally:
+                twms.twms.config.gpx_cache = old_cache
+
     def test_legacy_filter_smoke(self):
         image = Image.new("RGBA", (2, 1), (10, 20, 30, 255))
 
         filtered = twms.filter.raster(image, ("swaprb", "brightness:2"))
 
         self.assertEqual(filtered.getpixel((0, 0)), (60, 40, 20, 255))
+
+    @unittest.skipUnless(twms.filter.NUMPY_AVAILABLE, "numpy not installed")
+    def test_legacy_fusion_filter_is_quiet_and_uses_original_intensity(self):
+        image = Image.new("RGBA", (2, 1))
+        image.putdata([(10, 20, 30, 255), (0, 0, 0, 255)])
+        pan = Image.new("L", (2, 1))
+        pan.putdata([60, 60])
+        old_layers = twms.filter.config.layers
+        twms.filter.config.layers = {"pan": {"name": "Pan"}}
+        stdout = StringIO()
+        try:
+            with mock.patch("twms.filter.getimg", return_value=pan):
+                with contextlib.redirect_stdout(stdout):
+                    filtered = twms.filter.raster(image, ("fusion:pan",))
+        finally:
+            twms.filter.config.layers = old_layers
+
+        self.assertEqual(stdout.getvalue(), "")
+        self.assertEqual(filtered.getpixel((0, 0)), (10, 20, 30, 255))
+        self.assertEqual(filtered.getpixel((1, 0)), (0, 0, 0, 255))
+
+    def test_legacy_rectify_returns_projection_bounds_without_identity_trick(self):
+        bounds = twms.projections.projs["EPSG:3857"]["bounds"]
+        min_point = (float(str(bounds[0])), float(str(bounds[1])))
+        layer = {"prefix": "bounded", "proj": "EPSG:3857"}
+
+        with tempfile.TemporaryDirectory() as cache_root:
+            layer_root = os.path.join(cache_root, "bounded")
+            os.makedirs(layer_root)
+            with open(os.path.join(layer_root, "rectify.txt"), "w") as corr_file:
+                corr_file.write("27.0 53.0 27.1 53.1 user 2026-01-01T00:00:00Z\n")
+            old_cache = twms.correctify.config.tiles_cache
+            twms.correctify.config.tiles_cache = cache_root + os.sep
+            try:
+                self.assertEqual(twms.correctify.rectify(layer, min_point), min_point)
+            finally:
+                twms.correctify.config.tiles_cache = old_cache
 
     def test_legacy_wkt_drawing_without_color_parameter(self):
         status, content_type, body = twms.twms.twms_main(
@@ -444,6 +543,16 @@ class LegacySmokeTest(unittest.TestCase):
 
         self.assertEqual(canvas.tiles[(0, 0)]["im"].size, (32, 32))
         self.assertEqual(canvas.tiles[(0, 0)]["im"].mode, "RGBA")
+
+    def test_legacy_canvas_prepare_pixel_initializes_tile_once(self):
+        canvas = twms.canvas.WmsCanvas(tile_size=(32, 32))
+
+        canvas.PreparePixel(33, 65)
+
+        if "thread" in canvas.tiles[(1, 2)]:
+            canvas.tiles[(1, 2)]["thread"].join()
+        self.assertEqual(canvas.tiles[(1, 2)]["status"], "RD")
+        self.assertEqual(canvas.tiles[(1, 2)]["im"].size, (32, 32))
 
     def test_legacy_canvas_uses_default_upstream_timeout(self):
         canvas = twms.canvas.WmsCanvas(
@@ -574,7 +683,34 @@ class LegacySmokeTest(unittest.TestCase):
         self.assertEqual(doc["tiles"], ["http://example.test/osm/{z}/{x}/{y}.png"])
         self.assertEqual(doc["bounds"], [-180.0, -85.0511287798, 180.0, 85.0511287798])
         self.assertEqual(doc["minzoom"], 0)
-        self.assertEqual(doc["maxzoom"], 18)
+        self.assertEqual(doc["maxzoom"], 17)
+
+    def test_tilejson_maxzoom_is_last_requestable_zoom(self):
+        old_layers = twms.twms.config.layers
+        twms.twms.config.layers = {
+            "exclusive": {
+                "name": "Exclusive",
+                "prefix": "exclusive",
+                "ext": "png",
+                "proj": "EPSG:3857",
+                "max_zoom": 7,
+            }
+        }
+        try:
+            status, content_type, body = twms.twms.twms_main(
+                {
+                    "request": "GetTileJSON",
+                    "layers": "exclusive",
+                    "ref": "http://example.test/",
+                }
+            )
+
+            doc = json.loads(body)
+            self.assertEqual(status, 200)
+            self.assertEqual(content_type, "application/json")
+            self.assertEqual(doc["maxzoom"], 6)
+        finally:
+            twms.twms.config.layers = old_layers
 
     def test_tilejson_accepts_layer_bounds_alias(self):
         old_layers = twms.twms.config.layers
@@ -924,6 +1060,16 @@ class LegacySmokeTest(unittest.TestCase):
         self.assertEqual(projected[1], -maxbounds)
         self.assertEqual(projected[2], maxbounds)
         self.assertEqual(projected[3], maxbounds)
+
+    def test_pure_projection_roundtrips_match_legacy_smoke_point(self):
+        lon_lat = (27.6, 53.2)
+
+        for srs in ("EPSG:3857", "EPSG:3395"):
+            projected = twms.projections.from4326(lon_lat, srs)
+            roundtripped = twms.projections.to4326(projected, srs)
+
+            self.assertAlmostEqual(roundtripped[0], lon_lat[0], places=6)
+            self.assertAlmostEqual(roundtripped[1], lon_lat[1], places=6)
 
     def test_optional_pyproj_projection_uses_modern_transformer(self):
         if not hasattr(twms.projections.pyproj, "Transformer"):

--- a/tools/compile_correction.py
+++ b/tools/compile_correction.py
@@ -22,36 +22,37 @@ for lay in layers:
     src = lay + ".osm"
     if os.path.exists(src):
         corrfile = tiles_cache + lay + "/rectify.txt"
-        corr = open(corrfile, "w")
-        context = etree.iterparse(open(src))
-        for action, elem in context:
-            items = dict(elem.items())
-            ts = items.get("timestamp", ts)
+        with open(corrfile, "w") as corr:
+            with open(src, "rb") as source:
+                context = etree.iterparse(source)
+                for action, elem in context:
+                    items = dict(elem.items())
+                    ts = items.get("timestamp", ts)
 
-            #   print items
-            if elem.tag == "node":
-                nodes[int(items["id"])] = (float(items["lon"]), float(items["lat"]))
-            elif elem.tag == "nd":
-                curway.append(nodes[int(items["ref"])])
-            elif elem.tag == "tag":
-                if items["k"] == "user":
-                    user = items["v"]
-                if items["k"] == "timestamp":
-                    ts = items["v"]
-            elif elem.tag == "way":
-                ts = items.get("timestamp", ts)
-                print(
-                    "%s %s %s %s %s %s"
-                    % (
-                        curway[0][0],
-                        curway[0][1],
-                        curway[1][0],
-                        curway[1][1],
-                        user,
-                        ts,
-                    ),
-                    file=corr,
-                )
-                curway = []
-                user = default_user
-                ts = ""
+                    #   print items
+                    if elem.tag == "node":
+                        nodes[int(items["id"])] = (float(items["lon"]), float(items["lat"]))
+                    elif elem.tag == "nd":
+                        curway.append(nodes[int(items["ref"])])
+                    elif elem.tag == "tag":
+                        if items["k"] == "user":
+                            user = items["v"]
+                        if items["k"] == "timestamp":
+                            ts = items["v"]
+                    elif elem.tag == "way":
+                        ts = items.get("timestamp", ts)
+                        print(
+                            "%s %s %s %s %s %s"
+                            % (
+                                curway[0][0],
+                                curway[0][1],
+                                curway[1][0],
+                                curway[1][1],
+                                user,
+                                ts,
+                            ),
+                            file=corr,
+                        )
+                        curway = []
+                        user = default_user
+                        ts = ""

--- a/tools/decompile_correction.py
+++ b/tools/decompile_correction.py
@@ -2,32 +2,36 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 
-import sys
-
 
 tiles_cache = "/var/www/latlon/wms/cache/"
 layers = ["irs", "yhsat", "DGsat", "yasat"]
 
-out = sys.stdout
-
 for lay in layers:
     nid, wid = 1, 1
-    out = open(lay + ".osm", "w")
     corrfile = tiles_cache + lay + "/rectify.txt"
-    corr = open(corrfile, "r")
-    print('<osm version="0.6">', file=out)
-    for line in corr:
-        d, c, b, a, user, ts = line.split()
-        d, c, b, a = (float(d), float(c), float(b), float(a))
-        print('<node id="-%s" lon="%s" lat="%s" version="1" />' % (nid, d, c), file=out)
-        nid += 1
-        print('<node id="-%s" lon="%s" lat="%s" version="1" />' % (nid, b, a), file=out)
-        nid += 1
-        print('<way id="-%s" version="1">' % wid, file=out)
-        print(' <nd ref="-%s" />' % (nid - 2), file=out)
-        print(' <nd ref="-%s" />' % (nid - 1), file=out)
-        print(' <tag k="%s" v="%s" />"' % ("user", user), file=out)
-        print(' <tag k="%s" v="%s" />"' % ("timestamp", ts), file=out)
-        print("</way>", file=out)
-        wid += 1
-    print("</osm>", file=out)
+    with open(lay + ".osm", "w") as out:
+        with open(corrfile, "r") as corr:
+            print('<osm version="0.6">', file=out)
+            for line in corr:
+                d, c, b, a, user, ts = line.split()
+                d, c, b, a = (float(d), float(c), float(b), float(a))
+                print(
+                    '<node id="-%s" lon="%s" lat="%s" version="1" />'
+                    % (nid, d, c),
+                    file=out,
+                )
+                nid += 1
+                print(
+                    '<node id="-%s" lon="%s" lat="%s" version="1" />'
+                    % (nid, b, a),
+                    file=out,
+                )
+                nid += 1
+                print('<way id="-%s" version="1">' % wid, file=out)
+                print(' <nd ref="-%s" />' % (nid - 2), file=out)
+                print(' <nd ref="-%s" />' % (nid - 1), file=out)
+                print(' <tag k="%s" v="%s" />' % ("user", user), file=out)
+                print(' <tag k="%s" v="%s" />' % ("timestamp", ts), file=out)
+                print("</way>", file=out)
+                wid += 1
+            print("</osm>", file=out)

--- a/twms/bbox.py
+++ b/twms/bbox.py
@@ -5,8 +5,6 @@
 # the extent permitted by applicable law. You can redistribute it
 # and/or modify it under the terms specified in COPYING.
 
-import sys
-
 import projections
 
 
@@ -26,7 +24,7 @@ def point_is_in(bbox, point):
 
 def bbox_is_in(bbox_outer, bbox_to_check, fully=True):
     """
-    Check whether EPSG:4326 bbox is inside outer
+    Check whether an EPSG:4326 bbox is inside or intersects another bbox.
     """
     bo = normalize(bbox_outer)[0]
     bc = normalize(bbox_to_check)[0]
@@ -42,22 +40,6 @@ def bbox_is_in(bbox_outer, bbox_to_check, fully=True):
                 bo, bc = bc, bo
             return bc[1] <= bo[3]
         return False
-
-        return (
-            ((bo[0] <= bc[0] and bo[2] >= bc[0]) or (bo[0] <= bc[2] and bo[2] >= bc[2]))
-            and (
-                (bo[1] <= bc[1] and bo[3] >= bc[1])
-                or (bo[1] <= bc[3] and bo[3] >= bc[3])
-            )
-            or (
-                (bc[0] <= bo[0] and bc[2] >= bo[0])
-                or (bc[0] <= bo[2] and bc[2] >= bo[2])
-            )
-            and (
-                (bc[1] <= bo[1] and bc[3] >= bo[1])
-                or (bc[1] <= bo[3] and bc[3] >= bo[3])
-            )
-        )
 
 
 def add(b1, b2):
@@ -78,7 +60,11 @@ def expand_to_point(b1, p1):
 
 def normalize(bbox):
     """
-    Normalise EPSG:4326 bbox order. Returns normalized bbox, and whether it was flipped on horizontal axis.
+    Normalise EPSG:4326 bbox order.
+
+    Returns the normalized bbox and whether it was flipped on the vertical
+    coordinate axis. Longitudes may intentionally exceed 180 after wrapping;
+    tile math uses that to represent antimeridian-spanning boxes.
     """
 
     flip_h = False

--- a/twms/canvas.py
+++ b/twms/canvas.py
@@ -100,26 +100,30 @@ class WmsCanvas:
 
     def FetchTile(self, x, y):
         if (x, y) in self.tiles:
-            if self.tiles[(x, y)]["status"] == "DL":
-                self.tiles[(x, y)]["thread"].join()
+            tile = self.tiles[(x, y)]
+            if tile["status"] == "RD":
+                return
+            if tile["status"] == "DL" and tile.get("thread") is not threading.current_thread():
+                tile["thread"].join()
+                return
+
+        im = ""
+        if self.wms_url:
+            remote = self.ConstructTileUrl(x, y)
+            debug(remote)
+            ttz = datetime.datetime.now()
+            contents = urlopen(remote, timeout=self.UpstreamTimeout()).read()
+            debug("Download took %s" % str(datetime.datetime.now() - ttz))
+            im = Image.open(BytesIO(contents))
+            if im.mode != self.mode:
+                im = im.convert(self.mode)
         else:
-            im = ""
-            if self.wms_url:
-                remote = self.ConstructTileUrl(x, y)
-                debug(remote)
-                ttz = datetime.datetime.now()
-                contents = urlopen(remote, timeout=self.UpstreamTimeout()).read()
-                debug("Download took %s" % str(datetime.datetime.now() - ttz))
-                im = Image.open(BytesIO(contents))
-                if im.mode != self.mode:
-                    im = im.convert(self.mode)
-            else:
-                im = Image.new(self.mode, (self.tile_width, self.tile_height))
-                debug("blanking tile")
-            self.tiles[(x, y)] = {}
-            self.tiles[(x, y)]["im"] = im
-            self.tiles[(x, y)]["pix"] = im.load()
-            self.tiles[(x, y)]["status"] = "RD"
+            im = Image.new(self.mode, (self.tile_width, self.tile_height))
+            debug("blanking tile")
+        self.tiles[(x, y)] = {}
+        self.tiles[(x, y)]["im"] = im
+        self.tiles[(x, y)]["pix"] = im.load()
+        self.tiles[(x, y)]["status"] = "RD"
 
     def UpstreamTimeout(self):
         if self.timeout != "default":
@@ -135,10 +139,10 @@ class WmsCanvas:
         x = x % self.tile_height
         tile_y = int(y / self.tile_width)
         y = y % self.tile_width
-        if not (tile_x, tile_y):
+        if (tile_x, tile_y) not in self.tiles:
             self.tiles[(tile_x, tile_y)] = {}
             self.tiles[(tile_x, tile_y)]["status"] = "PP"
-        if not "pix" in self.tiles[(tile_x, tile_y)]:
+        if "pix" not in self.tiles[(tile_x, tile_y)]:
             if self.tiles[(tile_x, tile_y)]["status"] == "PP":
                 self.tiles[(tile_x, tile_y)]["status"] = "DL"
                 self.tiles[(tile_x, tile_y)]["thread"] = threading.Thread(

--- a/twms/config_loader.py
+++ b/twms/config_loader.py
@@ -8,6 +8,13 @@ import sys
 
 
 class LayerConfig(dict):
+    """Layer mapping that falls back to shared ``layer_defaults``.
+
+    TWMS layer configuration is intentionally plain Python.  This wrapper keeps
+    old ``layer["key"]`` callers working while letting new configs declare
+    common defaults once.
+    """
+
     def __init__(self, defaults, values):
         super().__init__(values)
         self.defaults = defaults
@@ -40,6 +47,8 @@ def _mimetype_from_extension(extension):
 
 
 def _normalize_format_metadata(layer, default_mimetype=None):
+    """Fill matching ``ext``/``mimetype`` fields without overwriting authors."""
+
     if "mimetype" in layer and "ext" not in layer:
         extension = _extension_from_mimetype(layer["mimetype"])
         if extension:
@@ -56,6 +65,8 @@ def _normalize_format_metadata(layer, default_mimetype=None):
 
 
 def _normalize_fetch_metadata(layer):
+    """Resolve tiny string fetcher aliases used by docs and old configs."""
+
     fetch = layer.get("fetch")
     if not isinstance(fetch, str):
         return
@@ -74,6 +85,8 @@ def _normalize_fetch_metadata(layer):
 
 
 def normalize_layer_metadata(module):
+    """Normalize metadata on a loaded config module in place."""
+
     default_mimetype = getattr(module, "default_format", None)
     layer_defaults = getattr(module, "layer_defaults", None)
     if isinstance(layer_defaults, dict):
@@ -87,6 +100,12 @@ def normalize_layer_metadata(module):
 
 
 def load_config(path):
+    """Load a TWMS Python config file and publish it as ``config``.
+
+    Many legacy modules still import ``config`` directly, so the loaded module
+    must be registered under both the package and historical top-level names.
+    """
+
     loader = importlib.machinery.SourceFileLoader("twms.config", path)
     spec = importlib.util.spec_from_loader("twms.config", loader)
     module = importlib.util.module_from_spec(spec)
@@ -98,6 +117,8 @@ def load_config(path):
 
 
 def load_default_config():
+    """Load the first existing config from system, package, then cwd paths."""
+
     if "config" in sys.modules:
         return sys.modules["config"]
 

--- a/twms/correctify.py
+++ b/twms/correctify.py
@@ -22,12 +22,12 @@ def has_corrections(layer):
 
 def corr_wkt(layer):
     corrfile = config.tiles_cache + layer.get("prefix", "") + "/rectify.txt"
-    corr = open(corrfile, "r")
     wkt = ""
-    for line in corr:
-        d, c, b, a, user, ts = line.split()
-        d, c, b, a = (float(d), float(c), float(b), float(a))
-        wkt += "POINT(%s %s),LINESTRING(%s %s,%s %s)," % (d, c, d, c, b, a)
+    with open(corrfile, "r") as corr:
+        for line in corr:
+            d, c, b, a, user, ts = line.split()
+            d, c, b, a = (float(d), float(c), float(b), float(a))
+            wkt += "POINT(%s %s),LINESTRING(%s %s,%s %s)," % (d, c, d, c, b, a)
     return wkt[:-1]
 
 
@@ -36,39 +36,39 @@ def rectify(layer, point):
     srs = layer["proj"]
     if not os.path.exists(corrfile):
         return point
-    corr = open(corrfile, "r")
     lons, lats = point
     loni, lati, lona, lata = projections.projs[projections.proj_alias.get(srs, srs)][
         "bounds"
     ]
-    if (lons is loni and lats is lati) or (lons is lona and lats is lata):
+    if (lons == loni and lats == lati) or (lons == lona and lats == lata):
         return point
     # print(pickle.dumps(coefs[layer]), file=sys.stderr)
     #    sys.stderr.flush()
     lonaz, loniz, lataz, latiz = lona, loni, lata, lati
     maxdist = 1.80
-    for line in corr:
-        d, c, b, a, user, ts = line.split()
-        d, c, b, a = (float(d), float(c), float(b), float(a))
-        # for d,c,b,a in coefs[layer]:
-        # print(a,b, distance(lons, lats, b, a), file=sys.stderr)
-        if distance(b, a, lons, lats) < maxdist:
-            if a > lats:
-                if distance(a, b, lats, lons) <= distance(lata, lona, lats, lons):
-                    lata = a
-                    lataz = c
-            if a < lats:
-                if distance(a, b, lats, lons) <= distance(lati, loni, lats, lons):
-                    lati = a
-                    latiz = c
-            if b > lons:
-                if distance(a, b, lats, lons) <= distance(lata, lona, lats, lons):
-                    lona = b
-                    lonaz = d
-            if b < lons:
-                if distance(a, b, lats, lons) <= distance(lati, loni, lats, lons):
-                    loni = b
-                    loniz = d
+    with open(corrfile, "r") as corr:
+        for line in corr:
+            d, c, b, a, user, ts = line.split()
+            d, c, b, a = (float(d), float(c), float(b), float(a))
+            # for d,c,b,a in coefs[layer]:
+            # print(a,b, distance(lons, lats, b, a), file=sys.stderr)
+            if distance(b, a, lons, lats) < maxdist:
+                if a > lats:
+                    if distance(a, b, lats, lons) <= distance(lata, lona, lats, lons):
+                        lata = a
+                        lataz = c
+                if a < lats:
+                    if distance(a, b, lats, lons) <= distance(lati, loni, lats, lons):
+                        lati = a
+                        latiz = c
+                if b > lons:
+                    if distance(a, b, lats, lons) <= distance(lata, lona, lats, lons):
+                        lona = b
+                        lonaz = d
+                if b < lons:
+                    if distance(a, b, lats, lons) <= distance(lati, loni, lats, lons):
+                        loni = b
+                        loniz = d
     #    print(loni, lati, lona, lata, distance(loni, lati, lona, lata), file=sys.stderr)
     #    print("clat:", (lata-lati)/(lataz-latiz), (lona-loni)/(lonaz-loniz), file=sys.stderr)
     #    sys.stderr.flush()

--- a/twms/daemon.py
+++ b/twms/daemon.py
@@ -13,7 +13,7 @@ import sys
 
 import web
 
-from twms import *
+from twms.twms import twms_main
 
 
 try:
@@ -29,7 +29,7 @@ ERROR = 500
 
 def handler(data):
     """
-    A handler for web.py.
+    Handle a normalized web.py request dictionary.
     """
     resp, ctype, content = twms_main(data)
     web.header("Content-Type", ctype)
@@ -44,6 +44,8 @@ urls = (
 
 class tilehandler:
     def GET(self, layers, z, x, y, format, rest):
+        """Serve a legacy /layer/z/x/y.ext tile URL."""
+
         if format is None:
             format = "jpeg"
         else:
@@ -61,6 +63,8 @@ class tilehandler:
 
 class mainhandler:
     def GET(self, crap):
+        """Serve query-string WMS/GetTile requests through web.py."""
+
         data = web.input()
         data = dict((k.lower(), data[k]) for k in iter(data))
         if "ref" not in data:

--- a/twms/drawing.py
+++ b/twms/drawing.py
@@ -7,13 +7,9 @@
 
 import array
 import math
-import os
-import sys
-import urllib
 
 import config
 import projections
-from gpxparse import GPXParser
 from PIL import Image, ImageColor, ImageDraw, ImageFont
 
 
@@ -72,7 +68,11 @@ def render_vector(
     pil_font=None,
 ):
     """
-    Renders a vector geometry on image.
+    Render one already-parsed vector geometry onto an image.
+
+    Coordinates arrive in EPSG:4326, are projected to the request SRS, then
+    mapped into image pixels.  The PIL backend gets integer coordinates because
+    some older Pillow drawing paths dislike subpixels.
     """
     if not color:
         color = config.geometry_color[geometry]
@@ -93,7 +93,6 @@ def render_vector(
     lo1, la1, lo2, la2 = bbox
     coords = projections.from4326(coords, srs)
     W, H = img.size
-    prevcoord = False
     coords = [
         (
             (coord[0] - lo1) * (W - 1) / abs(lo2 - lo1),
@@ -138,8 +137,7 @@ def render_vector(
         img = Image.frombuffer("RGBA", (W, H), surface.get_data(), "raw", "RGBA", 0, 1)
 
     else:
-        "falling back to PIL"
-        coord = [
+        coords = [
             (int(coord[0]), int(coord[1])) for coord in coords
         ]  # PIL dislikes subpixels
         draw = ImageDraw.Draw(img)

--- a/twms/fetchers.py
+++ b/twms/fetchers.py
@@ -5,11 +5,8 @@
 # the extent permitted by applicable law. You can redistribute it
 # and/or modify it under the terms specified in COPYING.
 
-import filecmp
 import hashlib
-import math
 import os
-import sys
 import threading
 import time
 from io import BytesIO
@@ -320,7 +317,6 @@ def WMS(z, x, y, this_layer):
 
 
 def Tile(z, x, y, this_layer):
-    global OSError, IOError
     d_tuple = z, x, y
     if _outside_zoom_limits(z, this_layer):
         return None

--- a/twms/filter.py
+++ b/twms/filter.py
@@ -21,13 +21,17 @@ from twms.twms import getimg
 
 try:
     import config
-except:
+except ImportError:
     pass
 
 
 def raster(result_img, filt, bbox=(-999, -999, 999, 9999), srs="EPSG:3857"):
     """
-    Applies various filters to image.
+    Apply requested raster filters to an image.
+
+    Filters are applied left-to-right.  Simple filter names mutate only the
+    supplied image; ``name:value`` filters use the value as a numeric argument
+    or, for ``fusion:<layer>``, as the panchromatic source layer name.
     """
     for ff in filt:
         if ff.split(":") == [ff]:
@@ -82,22 +86,15 @@ def raster(result_img, filt, bbox=(-999, -999, 999, 9999), srs="EPSG:3857"):
                     bbox, srs, [b, a], config.layers[tts], datetime.datetime.now(), []
                 )
                 pan_img = pan_img.convert("L")
-                print(pix.dtype)
-                print(pix[..., 1].shape)
 
                 pan = numpy.array(pan_img)
+                intensity = pix[..., 0] + pix[..., 1] + pix[..., 2]
+                intensity[intensity == 0] = 1
 
-                pix[..., 0] = (
-                    pix[..., 0] * pan / (pix[..., 0] + pix[..., 1] + pix[..., 2])
-                )
-                pix[..., 1] = (
-                    pix[..., 1] * pan / (pix[..., 0] + pix[..., 1] + pix[..., 2])
-                )
-                pix[..., 2] = (
-                    pix[..., 2] * pan / (pix[..., 0] + pix[..., 1] + pix[..., 2])
-                )
+                pix[..., 0] = pix[..., 0] * pan / intensity
+                pix[..., 1] = pix[..., 1] * pan / intensity
+                pix[..., 2] = pix[..., 2] * pan / intensity
 
-                print(pix.shape)
                 result_img = Image.fromarray(numpy.uint8(pix))
 
                 result_img = result_img.convert("RGBA")

--- a/twms/gpxparse.py
+++ b/twms/gpxparse.py
@@ -7,10 +7,7 @@
 
 import bz2
 import gzip
-import os
-import string
-import sys
-from xml.dom import Node, minidom
+from xml.dom import minidom
 
 
 class GPXParser:
@@ -20,23 +17,24 @@ class GPXParser:
         self.trknum = 0
         self.bbox = (999, 999, -999, -999)
         try:
-            file = open(filename)
-            signature = file.read(2)
-            file.close()
-            file = {
-                "BZ": lambda f: bz2.BZ2File(f),
-                "\x1f\x8b": lambda f: gzip.GzipFile(f),
-                "<?": lambda f: open(f),
+            with open(filename, "rb") as probe:
+                signature = probe.read(2)
+            gpx_file = {
+                b"BZ": lambda f: bz2.BZ2File(f),
+                b"\x1f\x8b": lambda f: gzip.GzipFile(f),
+                b"<?": lambda f: open(f, "rb"),
             }[signature](filename)
-        except (OSError, IOError):
+        except (OSError, IOError, KeyError):
             return
         try:
-            doc = minidom.parse(file)
+            doc = minidom.parse(gpx_file)
             doc.normalize()
         except (KeyboardInterrupt, SystemExit):
             raise
-        except:
+        except Exception:
             return  # handle this properly later
+        finally:
+            gpx_file.close()
         gpx = doc.documentElement
         for node in gpx.getElementsByTagName("trk"):
             self.parseTrack(node)
@@ -45,7 +43,7 @@ class GPXParser:
         # name = trk.getElementsByTagName('name')[0].firstChild.data
         name = self.trknum
         self.trknum += 1
-        if not name in self.tracks:
+        if name not in self.tracks:
             self.tracks[name] = {}
         minlat, minlon, maxlat, maxlon = self.bbox
         for trkseg in trk.getElementsByTagName("trkseg"):
@@ -60,14 +58,13 @@ class GPXParser:
                     maxlon = lon
                 if lon < minlon:
                     minlon = lon
-                #    ele = float(trkpt.getElementsByTagName('ele')[0].firstChild.data)
-                rfc3339 = trkpt.getElementsByTagName("time")[0].firstChild.data
                 self.pointnum += 1
                 self.tracks[name][self.pointnum] = {"lat": lat, "lon": lon}
         self.bbox = (minlon, minlat, maxlon, maxlat)
 
     def getTrack(self, name):
-        times = self.tracks[name].keys()
-        times.sort()
+        """Return track points in the original parsed order."""
+
+        times = sorted(self.tracks[name].keys())
         points = [self.tracks[name][time] for time in times]
         return [(point["lon"], point["lat"]) for point in points]

--- a/twms/overview.py
+++ b/twms/overview.py
@@ -6,7 +6,10 @@
 # and/or modify it under the terms specified in COPYING.
 
 import projections
-from config import *
+import config
+
+layers = config.layers
+wms_name = config.wms_name
 
 
 def _layer_bounds(layer):
@@ -34,7 +37,8 @@ def html(ref):
     resp += wms_name
     resp += "</h2><table>"
     for i in layers:
-        bbox = _layer_bounds(layers[i])
+        layer = layers[i]
+        bbox = _layer_bounds(layer)
         resp += '<tr><td><img src="'
         resp += (
             ref
@@ -43,14 +47,14 @@ def html(ref):
             + "&amp;bbox=%s,%s,%s,%s" % bbox
             + '&amp;width=200&amp;format=image/png" width="200" /></td><td><h3>'
         )
-        if "provider_url" in layers[i]:
+        if "provider_url" in layer:
             resp += '<a referrerpolicy="no-referrer" href="'
-            resp += layers[i]["provider_url"]
+            resp += layer["provider_url"]
             resp += '">'
-            resp += layers[i]["name"]
+            resp += layer["name"]
             resp += "</a>"
         else:
-            resp += layers[i]["name"]
+            resp += layer["name"]
         resp += (
             "</h3><b>Bounding box:</b> "
             + str(bbox)
@@ -58,7 +62,7 @@ def html(ref):
             % bbox
             + ")<br />"
         )
-        resp += "<b>Projection:</b> " + layers[i]["proj"] + "<br />"
+        resp += "<b>Projection:</b> " + layer["proj"] + "<br />"
         resp += "<b>WMS half-link:</b> " + ref + "?layers=" + i + "&amp;<br />"
         resp += (
             "<b>Tiles URL:</b> "
@@ -66,7 +70,7 @@ def html(ref):
             + ""
             + i
             + "/!/!/!."
-            + _layer_extension(layers[i])
+            + _layer_extension(layer)
             + "<br />"
         )
         resp += "</td></tr>"

--- a/twms/projections.py
+++ b/twms/projections.py
@@ -141,8 +141,6 @@ def _c4326t3395(t1, t2, lon, lat):
     Pure python 4326 -> 3395 transform. About 8x faster than pyproj.
     """
     E = 0.0818191908426
-    A = 20037508.342789
-    F = 53.5865938
     tmp = math.tan(0.78539816339744830962 + math.radians(lat) / 2.0)
     pow_tmp = math.pow(
         math.tan(
@@ -312,82 +310,3 @@ def transform(line, srs1, srs2):
         else:
             ans.append(p)
     return ans
-
-
-if __name__ == "__main__":
-    import debug
-
-    print(_c4326t3857(1, 2, 27.6, 53.2))
-    print(from4326((27.6, 53.2), "EPSG:3857"))
-    a = _c4326t3857(1, 2, 27.6, 53.2)
-    print(to4326(a, "EPSG:3857"))
-    print(_c3857t4326(1, 2, a[0], a[1]))
-    print("3395:")
-    print(_c4326t3395(1, 2, 27.6, 53.2))
-    print(from4326((27.6, 53.2), "EPSG:3395"))
-    a = _c4326t3395(1, 2, 27.6, 53.2)
-    print(to4326(a, "EPSG:3395"))
-    print(_c3395t4326(1, 2, a[0], a[1]))
-
-    a = debug.Timer("Pure python 4326<3857")
-    for i in xrange(0, 100000):
-        t = _c3857t4326(1, 2, 3072417.9458943508, 7020078.5326420991)
-    a.stop()
-    a = debug.Timer("TWMS wrapped 4326<3857")
-    for i in xrange(0, 100000):
-        t = to4326((3072417.9458943508, 7020078.5326420991), "EPSG:3857")
-    a.stop()
-    a = debug.Timer("Pyproj unwrapped 4326<3857")
-    pr1 = projs["EPSG:3857"]["proj"]
-    pr2 = projs["EPSG:4326"]["proj"]
-    for i in xrange(0, 100000):
-        t = pyproj.transform(pr1, pr2, 3072417.9458943508, 7020078.5326420991)
-    a.stop()
-
-    a = debug.Timer("Pure python 4326<3395")
-    for i in xrange(0, 100000):
-        t = _c3395t4326(1, 2, 3072417.9458943508, 7020078.5326420991)
-    a.stop()
-    a = debug.Timer("TWMS wrapped 4326<3395")
-    for i in xrange(0, 100000):
-        t = to4326((3072417.9458943508, 7020078.5326420991), "EPSG:3395")
-    a.stop()
-    a = debug.Timer("Pyproj unwrapped 4326<3395")
-    pr1 = projs["EPSG:3395"]["proj"]
-    pr2 = projs["EPSG:4326"]["proj"]
-    for i in xrange(0, 100000):
-        t = pyproj.transform(pr1, pr2, 3072417.9458943508, 7020078.5326420991)
-    a.stop()
-
-    a = debug.Timer("Pure python 4326>3857")
-    for i in xrange(0, 100000):
-        t = _c4326t3857(1, 2, 27.6, 53.2)
-    a.stop()
-    a = debug.Timer("TWMS wrapped 4326>3857")
-    for i in xrange(0, 100000):
-        t = from4326((27.6, 53.2), "EPSG:3857")
-    a.stop()
-    a = debug.Timer("Pyproj unwrapped 4326>3857")
-    pr2 = projs["EPSG:3857"]["proj"]
-
-    pr1 = projs["EPSG:4326"]["proj"]
-    for i in xrange(0, 100000):
-        t = pyproj.transform(pr1, pr2, 27.6, 53.2)
-    a.stop()
-
-    a = debug.Timer("Pure python 4326>3395")
-    for i in xrange(0, 100000):
-        t = _c4326t3395(1, 2, 27.6, 53.2)
-    a.stop()
-    a = debug.Timer("TWMS wrapped 4326>3395")
-    for i in xrange(0, 100000):
-        t = from4326((27.6, 53.2), "EPSG:3395")
-    a.stop()
-    a = debug.Timer("Pyproj unwrapped 4326>3395")
-    pr2 = projs["EPSG:3395"]["proj"]
-    pr1 = projs["EPSG:4326"]["proj"]
-    for i in xrange(0, 100000):
-        t = pyproj.transform(pr1, pr2, 27.6, 53.2)
-    a.stop()
-
-    pass

--- a/twms/reproject.py
+++ b/twms/reproject.py
@@ -5,13 +5,12 @@
 # the extent permitted by applicable law. You can redistribute it
 # and/or modify it under the terms specified in COPYING.
 
-import sys
-
 import projections
-from PIL import Image
 
 
 def reproject(image, bbox, srs_from, srs_to):
+    """Nearest-neighbour reprojection for small legacy raster overlays."""
+
     out = image.copy()
     op = out.load()
     il = image.load()

--- a/twms/sketch.py
+++ b/twms/sketch.py
@@ -5,17 +5,25 @@
 # the extent permitted by applicable law. You can redistribute it
 # and/or modify it under the terms specified in COPYING.
 
-from bbox import *
+from bbox import point_is_in
 
 
 string = "abcdefghijklmnopqrstuvwxyz012345ABCDEFGHIJKLMNOPQRSTUVWXYZ6789{}"
 
 
 def decode(bbox, sketch):
+    """Decode a sketch string.
+
+    The historical decoder was never completed; keep the stub importable until
+    the sketch URL format gets real users again.
+    """
+
     version, sketch = sketch.split(";", 1)
 
 
 def encode_point(bbox, point, length, length_out=None):
+    """Encode a point relative to a bbox using TWMS' compact sketch alphabet."""
+
     if not length_out:
         length_out = length
     code = "."
@@ -26,7 +34,6 @@ def encode_point(bbox, point, length, length_out=None):
     lon, lat = point
     lon = (lon - bbox[0]) / (bbox[2] - bbox[0])  # normalizing points to bbox
     lat = (lat - bbox[1]) / (bbox[3] - bbox[1])
-    lats, lons = [], []
 
     for i in range(0, length):
         latt = int(lat * 8)
@@ -38,6 +45,8 @@ def encode_point(bbox, point, length, length_out=None):
 
 
 def decode_point(bbox, code):
+    """Decode one compact sketch point back into lon/lat."""
+
     lat, lon = (0, 0)
     if code[0] == ".":
         code = code[1:]

--- a/twms/tilejson.py
+++ b/twms/tilejson.py
@@ -44,6 +44,12 @@ def _tile_extension(config, layer_names, format_name):
     return config.default_format.lower().replace("image/", "").replace("jpeg", "jpg")
 
 
+def _requestable_maxzoom(exclusive_maxzoom):
+    """Convert TWMS' historical exclusive max zoom to TileJSON inclusive zoom."""
+
+    return max(0, exclusive_maxzoom - 1)
+
+
 def document(config, layers, ref, format_name=""):
     layer_names = _layer_names(config, layers)
     layer_items = [config.layers[name] for name in layer_names]
@@ -52,7 +58,9 @@ def document(config, layers, ref, format_name=""):
         bounds = bbox.add(bounds, _layer_bounds(config, layer))
 
     minzoom = max(layer.get("min_zoom", 0) for layer in layer_items)
-    maxzoom = min(layer.get("max_zoom", config.default_max_zoom) for layer in layer_items)
+    maxzoom = _requestable_maxzoom(
+        min(layer.get("max_zoom", config.default_max_zoom) for layer in layer_items)
+    )
     center = [
         (bounds[0] + bounds[2]) / 2.0,
         (bounds[1] + bounds[3]) / 2.0,

--- a/twms/twms.py
+++ b/twms/twms.py
@@ -7,13 +7,12 @@
 # and/or modify it under the terms specified in COPYING.
 
 import datetime
-import math
 import os
 import sys
 import time
-import urllib
 from collections import OrderedDict
 from io import BytesIO
+from urllib.request import urlretrieve
 
 sys.path.append(os.path.join(os.path.dirname(__file__)))
 
@@ -35,7 +34,6 @@ import wmts
 from bbox import expand_to_point, zoom_for_bbox
 from gpxparse import GPXParser
 from PIL import Image, ImageColor, ImageOps
-from reproject import reproject
 from twms.image_compat import resampling_lanczos
 
 
@@ -168,7 +166,7 @@ def twms_main(data):
             if not os.path.exists(config.gpx_cache):
                 os.makedirs(config.gpx_cache)
             if not os.path.exists(local_gpx):
-                urllib.urlretrieve(
+                urlretrieve(
                     "http://www.openstreetmap.org/trace/%s/data" % g, local_gpx
                 )
             if not track:
@@ -487,7 +485,6 @@ def tile_image(layer, z, x, y, start_time, again=False, trybetter=True, real=Fal
         fully=False,
     ):
         return None
-    global cached_objs
     if "prefix" in layer:
         cached = _ram_cache_get(_ram_cache_key(layer, z, x, y))
         if cached is not None:
@@ -506,7 +503,6 @@ def tile_image(layer, z, x, y, start_time, again=False, trybetter=True, real=Fal
                     if os.stat(f).st_mtime < (time.time() - layer["cache_ttl"]):
                         os.remove(f)
 
-        gpt_image = False
         try:
             "trying to create local cache directory, if it doesn't exist"
             os.makedirs("/".join(local.split("/")[:-1]))
@@ -631,7 +627,6 @@ def getimg(bbox, request_proj, size, layer, start_time, force):
         bbox_4 = bb4
     bbox = expand_to_point(bbox, bbox_4)
 
-    global cached_objs
     H, W = size
 
     max_zoom = layer.get("max_zoom", config.default_max_zoom)
@@ -664,7 +659,6 @@ def getimg(bbox, request_proj, size, layer, start_time, force):
     out = Image.new("RGBA", (x, y))
     for x in range(from_tile_x, to_tile_x + 1):
         for y in range(to_tile_y, from_tile_y + 1):
-            got_image = False
             im1 = tile_image(layer, zoom, x, y, start_time, real=True)
             if im1:
                 if "prefix" in layer:


### PR DESCRIPTION
This keeps the broader modernization from Komzpa/twms#23, then tightens a few legacy paths that deserved a full codebase pass before review.

### What changed

- preserve the tiny architecture while making the old WSGI and package imports explicit
- keep the historical keyboard-suffix release version (`0.07z`, packaging `0.7+z`)
- add a stdlib HTTP entry point while preserving the `web.py` entry point for old Windows/JOSM-style bundles
- normalize layer metadata so `ext`, `mimetype`, shared `layer_defaults`, and string fetcher aliases work consistently across overview, JOSM imagery XML, TileJSON, WMTS, WMS, and direct tile paths
- publish TileJSON 3.0.0 with the historical exclusive `max_zoom` converted to TileJSON's inclusive `maxzoom`
- keep the core projection shortlist pure-Python and make optional pyproj projections explicit
- preserve legacy GetTile/WMS behavior while adding bounded upstream timeouts, request headers, stale-cache fallback, TNE handling, z/x/y cache layout support, and response-cache regression coverage
- modernize legacy Python 3 trouble spots: GPX download/import path, GPX parser byte handling and point order, Pillow resampling compatibility, antimeridian bbox normalization, correction file handling, correction XML decompile output, fusion filter stdout/noise and intensity math
- move the projection timing snippet into `tests/bench_projections.py` and include tests/bench files in the sdist

### Validation

- `ruff check . --select F,E713,E722 --output-format=full`
- `pyflakes .`
- `git diff --check`
- `python -m compileall -q twms tools tests`
- `python -m unittest discover -s tests -v` — 87 tests, 1 optional-projection skip
- `python tests/bench_projections.py`
- `python -m build`
- `codex review --base origin/master`
- `codex review --uncommitted`
